### PR TITLE
Implement core parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,7 @@ dependencies = [
 name = "markflow-core"
 version = "0.0.1"
 dependencies = [
+ "log",
  "lol_html",
  "markdown",
  "pulldown-cmark",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,10 +286,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "markdown"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5cab8f2cadc416a82d2e783a1946388b31654d391d1c7d92cc1f03e295b1deb"
+dependencies = [
+ "unicode-id",
+]
+
+[[package]]
 name = "markflow-core"
 version = "0.0.1"
 dependencies = [
  "lol_html",
+ "markdown",
  "pulldown-cmark",
  "thiserror",
 ]
@@ -626,6 +636,12 @@ name = "unicase"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+
+[[package]]
+name = "unicode-id"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ba288e709927c043cbe476718d37be306be53fb1fafecd0dbe36d072be2580"
 
 [[package]]
 name = "unicode-ident"

--- a/TODO.md
+++ b/TODO.md
@@ -1,113 +1,72 @@
-## 🚀 Markflow Development Master Plan
+# 🚀 Markflow Development Roadmap
 
 | | |
 | :--- | :--- |
-| **Overview** | Next-generation streaming Markdown/MDX engine built with **Rust**. |
 | **Objective** | **Dramatically improve build performance** in Web frameworks (Astro, Next.js, Nuxt) and eliminate reliance on JavaScript dependencies. |
-| **Current Status** | Planning Phase (Phase 0) |
+| **Current Status** | 🚧 Phase 1: Core Engine Refactoring |
 
------
+## 🏃 In Progress
 
-## 1. Core Architecture Design
+### Phase 1: Core Engine Refactoring
+> **Goal:** Transition from prototype parser to `markdown-rs` for spec compliance and performance.
 
-### Basic Principles
+- [ ] **Core Parser Implementation**
+    - [ ] Remove `pulldown-cmark` dependency
+    - [ ] Introduce [`markdown-rs`](https://github.com/wooorm/markdown-rs)
+    - [ ] Verify basic Markdown parsing functionality with new parser
+- [ ] **WASM Bindings (Enhancement)**
+    - [ ] Expand `crates/wasm` to support streaming APIs (currently minimal wrapper)
 
-  * Zero-Copy Streaming: Avoid holding the entire document in memory from input to output.
-  * Hybrid Distribution: Provide NAPI-RS for build-time operations and WASM for runtime usage.
-  * Modular Pipeline: Input $\rightarrow$ Parser (Pull) $\rightarrow$ Adapter (Glue) $\rightarrow$ Rewriter (Push) $\rightarrow$ Output.
+## ✅ Done
 
-### Data Flow Diagram (Mermaid)
+### Phase 0: Initialization
+- [x] **Repository Setup**
+    - [x] Set up repository and `cargo` workspace (`core`, `napi`, `wasm`)
+    - [x] CI/CD pipeline configuration (GitHub Actions)
 
-```mermaid
-graph TD
-    Input[Input Stream] -->|Bytes| Parser[Core Parser (markdown-rs)]
-    Parser -->|Events| Processor[Event Processor (Directives)]
-    Processor -->|Modified Events| Glue[The Glue (PipeAdapter)]
-    Glue -->|Bytes| Rewriter[Streaming Rewriter (lol_html)]
-    Rewriter -->|Target Bytes| Output[Output Stream]
-```
+### Phase 1: Foundation Prototypes
+- [x] **The Glue (PipeAdapter)**
+    - [x] Implement adapter connecting `Iterator<Item=Event>` to `io::Write` (`crates/core/src/adapter.rs`)
+    - [x] Benchmark stream connection (`benchmarks/stream_bench.rs`)
+- [x] **Streaming Rewriter**
+    - [x] Embed `lol_html`
+    - [x] Implement basic tag rewriting (lazy images) (`crates/core/src/streaming_rewriter.rs`)
+- [x] **NAPI Bindings**
+    - [x] Set up `napi-rs`
+    - [x] Expose basic functions (`parse`, `parse_with_options`)
+    - [x] Verify Node.js interoperability
 
-## 2. Implementation Roadmap
-
-### Phase 1: Core Engine & The Glue (Foundation Building)
-
-Goal: Complete a Rust-only prototype that converts Markdown to HTML at high speed.
-
-* Repository Setup
-  * [ ] Set up repository
-  * [ ] Create Rust workspace (`cargo new --lib`)
-  * [ ] Initial CI/CD pipeline configuration (GitHub Actions)
-* Core Parser Implementation
-  * [ ] Introduce `markdown-rs`)
-  * [ ] Verify basic Markdown parsing functionality
-* The Glue (PipeAdapter) Implementation **【Top Priority】**
-  * [ ] Implement an adapter that accepts `Iterator<Item=Event>` and streams it to `io::Write`
-  * [ ] Benchmark stream connection to avoid buffering
-* Streaming Rewriter Integration
-  * [ ] Embed `lol_html`
-  * [ ] Implement HTML tag rewriting (e.g., adding `lazy` attribute to `<img>` tags)
-* NAPI Bindings
-  * [ ] Set up `napi-rs`
-  * [ ] Expose a basic function that accepts a string and returns a string from Node.js
+## 📋 Backlog
 
 ### Phase 2: Astro Integration (Content Layer API)
+> **Goal:** Make the engine functional as an Astro v5 Loader.
 
-Goal: Make the engine functional as an Astro v5 Loader and usable in real-world projects.
-
-* Astro Loader Prototype
-      * [ ] Implement a Loader readable from `src/content/config.ts`
-      * [ ] Output data that conforms to the `RenderedContent` type
-* MDX Support (Step 1: Hybrid Bridge)
-      * [ ] Process to pass JSX blocks through as "raw text"
-      * [ ] Verification of handover to the standard Astro pipeline
-* MDX Support (Step 2: Native Compiler)
-      * [ ] Introduce `swc_core`
-      * [ ] Implement JSX code generation logic within Rust
-      * [ ] Detect `client:*` directives and maintain hydration
-* Performance Measurement
-      * [ ] Compare build times for a 1000-page site (vs. Standard Astro)
+- [ ] **Astro Loader Prototype**
+    - [ ] Implement Loader readable from `src/content/config.ts`
+    - [ ] Output data conforming to `RenderedContent` type
+- [ ] **MDX Support (Step 1: Hybrid Bridge)**
+    - [ ] Pass JSX blocks through as "raw text"
+    - [ ] Verify handover to standard Astro pipeline
+- [ ] **MDX Support (Step 2: Native Compiler)**
+    - [ ] Introduce `swc_core`
+    - [ ] Implement JSX code generation logic in Rust
+    - [ ] Detect `client:*` directives and maintain hydration
+- [ ] **Performance Measurement**
+    - [ ] Compare build times for a 1000-page site (vs. Standard Astro)
 
 ### Phase 3: Universal Deployment (Nuxt & Next.js)
+> **Goal:** Abstract framework-specific differences.
 
-Goal: Abstract framework-specific differences and expand the ecosystem.
+- [ ] **Nuxt (Content v3) Support**
+    - [ ] Transformer Implementation (MDC syntax support)
+    - [ ] Serialize to Minimal Tree (JSON AST)
+    - [ ] Metadata Extraction (SQL storage structure)
+- [ ] **Next.js (App Router / Turbopack) Support**
+    - [ ] Implement `markflow-loader` (Webpack)
+    - [ ] RSC Support (JSX generation for Server Components)
+    - [ ] Unify build config via `unplugin`
 
-#### Nuxt (Content v3) Support
-
-* [ ] Transformer Implementation
-  * [ ] Support for MDC syntax (`::alert`) via `markdown-rs` extensions
-  * [ ] Serialization process to Minimal Tree (JSON AST) for Nuxt
-* [ ] Metadata Extraction
-  * [ ] Output structured data for SQL storage
-
-#### Next.js (App Router / Turbopack) Support
-
-* [ ] Webpack Loader Creation
-  * [ ] Implement `markflow-loader`
-* [ ] RSC (React Server Components) Support
-  * [ ] JSX generation for Server Components
-* [ ] `unplugin` Integration
-  * [ ] Unify build configuration (Vite/Webpack/Rspack)
-
-### Phase 4: Ecosystem & Optimization (Future)
-
-* [ ] WASM Plugin System: Mechanism to load user-defined logic via WASM.
-* [ ] Rust-native Syntax Highlighting: Integrate `syntect` or `tree-sitter`.
-* [ ] Turbopack Native Plugin: Support for Next.js's official Rust plugin system.
-
-## 3. Technology Stack Selection
-
-| Category | Technology/Crate | Purpose |
-| :--- | :--- | :--- |
-| **Language** | **Rust 2021** | Core Logic |
-| **Parser** | **`markdown-rs`** | MDX/CommonMark Parsing (micromark compatible) |
-| **Bridge** | **`napi-rs`** | High-speed communication with Node.js (V8) |
-| **Rewriter** | **`lol_html`** | Streaming HTML Rewriting |
-| **AST/Gen** | **`swc_core`** | JavaScript/JSX AST Construction and Code Generation |
-| **Concurrency**| **`rayon`** | Parallel Processing (File reading, etc.) |
-| **Highlight** | **`syntect`** | Build-time Syntax Highlighting |
-
-## 4. Risks and Issue Management ⚠️
-
-* MDX Complexity: The limit of accuracy for parsing nested JSX and dynamic JavaScript expressions.
-* Turbopack Specification Changes: Potential follow-up costs due to the Next.js plugin API being undetermined.
-* Ecosystem Compatibility: Speed of providing alternatives (WASM plugins) for the inability to use existing Remark plugins.
+### Phase 4: Ecosystem & Optimization
+- [ ] **WASM Plugin System**: Load user-defined logic via WASM.
+- [ ] **Rust-native Syntax Highlighting**: Integrate `syntect` or `tree-sitter`.
+- [ ] **Turbopack Native Plugin**: Support Next.js official Rust plugin system.

--- a/TODO.md
+++ b/TODO.md
@@ -11,9 +11,10 @@
 > **Goal:** Transition from prototype parser to `markdown-rs` for spec compliance and performance.
 
 - [ ] **Core Parser Implementation**
-    - [ ] Remove `pulldown-cmark` dependency
-    - [ ] Introduce [`markdown-rs`](https://github.com/wooorm/markdown-rs)
-    - [ ] Verify basic Markdown parsing functionality with new parser
+    - [ ] Remove `pulldown-cmark` dependency (blocked by Event enum replacement)
+    - [x] Introduce [`markdown-rs`](https://github.com/wooorm/markdown-rs) as the default parser
+    - [x] Verify basic Markdown parsing functionality with new parser
+    - [ ] Define internal `Event` enum and drop `pulldown-cmark` type usage
 - [ ] **WASM Bindings (Enhancement)**
     - [ ] Expand `crates/wasm` to support streaming APIs (currently minimal wrapper)
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,3 +9,8 @@ license.workspace = true
 lol_html = "2.0"
 pulldown-cmark = { version = "0.13", default-features = false, features = ["html"] }
 thiserror = "2.0.17"
+markdown = { version = "1.0.0-alpha.16", optional = true }
+
+[features]
+default = []
+markdown-rs = ["markdown"]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,8 +9,5 @@ license.workspace = true
 lol_html = "2.0"
 pulldown-cmark = { version = "0.13", default-features = false, features = ["html"] }
 thiserror = "2.0.17"
-markdown = { version = "1.0.0-alpha.16", optional = true }
-
-[features]
-default = []
-markdown-rs = ["markdown"]
+markdown = "1.0.0-alpha.16"
+log = "0.4"

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,6 +1,5 @@
 #![deny(missing_docs)]
 //! Streaming Markdown core utilities: parser, MarkdownStream, and HTML rewriter glue.
-use thiserror::Error;
 
 /// Markdown event to `io::Write` bridge utilities.
 pub mod adapter;
@@ -9,7 +8,16 @@ pub mod streaming_rewriter;
 pub use adapter::MarkdownStream;
 pub use streaming_rewriter::{RewriteOptions, StreamingRewriter};
 
+use pulldown_cmark::Event;
+#[cfg(not(feature = "markdown-rs"))]
 use pulldown_cmark::{Options, Parser};
+use thiserror::Error;
+
+#[cfg(feature = "markdown-rs")]
+use std::marker::PhantomData;
+
+#[cfg(feature = "markdown-rs")]
+mod markdown_adapter;
 
 /// Errors that can occur during Markdown processing.
 #[derive(Debug, Error)]
@@ -20,16 +28,19 @@ pub enum MarkflowError {
     /// UTF-8 encoding error.
     #[error("Encoding error: {0}")]
     EncodingError(#[from] std::string::FromUtf8Error),
+    /// markdown-rs parser error surfaced through the adapter.
+    #[error("markdown-rs error: {0}")]
+    MarkdownAdapter(String),
 }
 
 /// to get an Event Iterator from a string slice.
-pub fn get_event_iterator(input: &str) -> Parser<'_> {
-    Parser::new_ext(input, Options::empty())
+pub fn get_event_iterator(input: &str) -> Result<MarkdownEventStream<'_>, MarkflowError> {
+    MarkdownEventStream::new(input)
 }
 
 /// parses Markdown and rewrites the resulting HTML stream with the default rewrite options.
 pub fn parse(input: &str) -> Result<String, MarkflowError> {
-    let events = get_event_iterator(input);
+    let events = get_event_iterator(input)?;
     let rewriter = StreamingRewriter::new(Vec::new(), RewriteOptions::default());
 
     let rewriter = events.stream_to_writer(rewriter)?;
@@ -37,6 +48,78 @@ pub fn parse(input: &str) -> Result<String, MarkflowError> {
     let output = rewriter.into_inner()?;
     let string = String::from_utf8(output)?;
     Ok(string)
+}
+
+/// Unified event stream returned by [`get_event_iterator`].
+pub enum MarkdownEventStream<'input> {
+    /// Event iterator powered by `pulldown-cmark` (default feature set).
+    #[cfg(not(feature = "markdown-rs"))]
+    Pulldown(PulldownEventIterator<'input>),
+    /// Event iterator backed by `markdown-rs` when the feature flag is enabled.
+    #[cfg(feature = "markdown-rs")]
+    MarkdownRs {
+        /// markdown-rs backed iterator.
+        iter: markdown_adapter::MarkdownRsEventIter,
+        /// Marker tying the enum to the caller's lifetime for API parity.
+        _marker: PhantomData<&'input ()>,
+    },
+}
+
+impl<'input> MarkdownEventStream<'input> {
+    fn new(input: &'input str) -> Result<Self, MarkflowError> {
+        #[cfg(feature = "markdown-rs")]
+        {
+            let iterator = markdown_adapter::MarkdownRsEventIter::new(input)
+                .map_err(|err| MarkflowError::MarkdownAdapter(err.to_string()))?;
+            return Ok(Self::MarkdownRs {
+                iter: iterator,
+                _marker: PhantomData,
+            });
+        }
+
+        #[cfg(not(feature = "markdown-rs"))]
+        {
+            Ok(Self::Pulldown(PulldownEventIterator::new(input)))
+        }
+    }
+}
+
+impl<'input> Iterator for MarkdownEventStream<'input> {
+    type Item = Event<'static>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            #[cfg(not(feature = "markdown-rs"))]
+            MarkdownEventStream::Pulldown(iter) => iter.next(),
+            #[cfg(feature = "markdown-rs")]
+            MarkdownEventStream::MarkdownRs { iter, .. } => iter.next(),
+        }
+    }
+}
+
+/// Wrapper over the legacy `pulldown-cmark` parser, exposed so callers can
+/// inspect the iterator type behind the default feature set.
+#[cfg(not(feature = "markdown-rs"))]
+pub struct PulldownEventIterator<'input> {
+    inner: Parser<'input>,
+}
+
+#[cfg(not(feature = "markdown-rs"))]
+impl<'input> PulldownEventIterator<'input> {
+    fn new(input: &'input str) -> Self {
+        Self {
+            inner: Parser::new_ext(input, Options::empty()),
+        }
+    }
+}
+
+#[cfg(not(feature = "markdown-rs"))]
+impl<'input> Iterator for PulldownEventIterator<'input> {
+    type Item = Event<'static>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(Event::into_static)
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -8,15 +8,8 @@ pub mod streaming_rewriter;
 pub use adapter::MarkdownStream;
 pub use streaming_rewriter::{RewriteOptions, StreamingRewriter};
 
-use pulldown_cmark::Event;
-#[cfg(not(feature = "markdown-rs"))]
-use pulldown_cmark::{Options, Parser};
 use thiserror::Error;
 
-#[cfg(feature = "markdown-rs")]
-use std::marker::PhantomData;
-
-#[cfg(feature = "markdown-rs")]
 mod markdown_adapter;
 
 /// Errors that can occur during Markdown processing.
@@ -33,9 +26,12 @@ pub enum MarkflowError {
     MarkdownAdapter(String),
 }
 
-/// to get an Event Iterator from a string slice.
-pub fn get_event_iterator(input: &str) -> Result<MarkdownEventStream<'_>, MarkflowError> {
-    MarkdownEventStream::new(input)
+/// Returns an iterator over Markdown events backed by `markdown-rs`.
+pub fn get_event_iterator(
+    input: &str,
+) -> Result<markdown_adapter::MarkdownRsEventIter, MarkflowError> {
+    markdown_adapter::MarkdownRsEventIter::new(input)
+        .map_err(|err| MarkflowError::MarkdownAdapter(err.to_string()))
 }
 
 /// parses Markdown and rewrites the resulting HTML stream with the default rewrite options.
@@ -50,77 +46,8 @@ pub fn parse(input: &str) -> Result<String, MarkflowError> {
     Ok(string)
 }
 
-/// Unified event stream returned by [`get_event_iterator`].
-pub enum MarkdownEventStream<'input> {
-    /// Event iterator powered by `pulldown-cmark` (default feature set).
-    #[cfg(not(feature = "markdown-rs"))]
-    Pulldown(PulldownEventIterator<'input>),
-    /// Event iterator backed by `markdown-rs` when the feature flag is enabled.
-    #[cfg(feature = "markdown-rs")]
-    MarkdownRs {
-        /// markdown-rs backed iterator.
-        iter: markdown_adapter::MarkdownRsEventIter,
-        /// Marker tying the enum to the caller's lifetime for API parity.
-        _marker: PhantomData<&'input ()>,
-    },
-}
-
-impl<'input> MarkdownEventStream<'input> {
-    fn new(input: &'input str) -> Result<Self, MarkflowError> {
-        #[cfg(feature = "markdown-rs")]
-        {
-            let iterator = markdown_adapter::MarkdownRsEventIter::new(input)
-                .map_err(|err| MarkflowError::MarkdownAdapter(err.to_string()))?;
-            return Ok(Self::MarkdownRs {
-                iter: iterator,
-                _marker: PhantomData,
-            });
-        }
-
-        #[cfg(not(feature = "markdown-rs"))]
-        {
-            Ok(Self::Pulldown(PulldownEventIterator::new(input)))
-        }
-    }
-}
-
-impl<'input> Iterator for MarkdownEventStream<'input> {
-    type Item = Event<'static>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self {
-            #[cfg(not(feature = "markdown-rs"))]
-            MarkdownEventStream::Pulldown(iter) => iter.next(),
-            #[cfg(feature = "markdown-rs")]
-            MarkdownEventStream::MarkdownRs { iter, .. } => iter.next(),
-        }
-    }
-}
-
-/// Wrapper over the legacy `pulldown-cmark` parser, exposed so callers can
-/// inspect the iterator type behind the default feature set.
-#[cfg(not(feature = "markdown-rs"))]
-pub struct PulldownEventIterator<'input> {
-    inner: Parser<'input>,
-}
-
-#[cfg(not(feature = "markdown-rs"))]
-impl<'input> PulldownEventIterator<'input> {
-    fn new(input: &'input str) -> Self {
-        Self {
-            inner: Parser::new_ext(input, Options::empty()),
-        }
-    }
-}
-
-#[cfg(not(feature = "markdown-rs"))]
-impl<'input> Iterator for PulldownEventIterator<'input> {
-    type Item = Event<'static>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next().map(Event::into_static)
-    }
-}
+/// Iterator alias so callers don't need to depend on the adapter module path.
+pub type MarkdownEventStream = markdown_adapter::MarkdownRsEventIter;
 
 #[cfg(test)]
 mod tests {

--- a/crates/core/src/markdown_adapter.rs
+++ b/crates/core/src/markdown_adapter.rs
@@ -1,0 +1,261 @@
+#![cfg(feature = "markdown-rs")]
+//! Adapter that exposes `markdown-rs` AST nodes as `pulldown_cmark::Event`s.
+
+use markdown::{ParseOptions, mdast, message::Message, to_mdast};
+use pulldown_cmark::{Alignment, CowStr, Event, HeadingLevel, LinkType, Tag};
+
+/// Iterator that yields `pulldown_cmark` events backed by `markdown-rs`.
+///
+/// The adapter currently materializes the AST so we can progressively map the
+/// constructs we care about onto the legacy event pipeline. Streaming will be
+/// re-introduced once we drop `pulldown_cmark` entirely.
+pub struct MarkdownRsEventIter {
+    events: Vec<Event<'static>>,
+    cursor: usize,
+}
+
+impl MarkdownRsEventIter {
+    /// Parses the input with `markdown-rs` and prepares an event stream.
+    pub fn new(input: &str) -> Result<Self, Message> {
+        let tree = to_mdast(input, &ParseOptions::default())?;
+        let mut builder = EventBuilder::default();
+        builder.visit(&tree);
+        Ok(Self {
+            events: builder.events,
+            cursor: 0,
+        })
+    }
+}
+
+impl Iterator for MarkdownRsEventIter {
+    type Item = Event<'static>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.cursor >= self.events.len() {
+            None
+        } else {
+            let event = self.events[self.cursor].clone();
+            self.cursor += 1;
+            Some(event)
+        }
+    }
+}
+
+#[derive(Default)]
+struct EventBuilder {
+    events: Vec<Event<'static>>,
+    tight_list_depth: usize,
+}
+
+impl EventBuilder {
+    fn visit(&mut self, node: &mdast::Node) {
+        match node {
+            mdast::Node::Root(root) => self.visit_children(&root.children),
+            mdast::Node::Paragraph(paragraph) => {
+                if self.tight_list_depth > 0 {
+                    self.visit_children(&paragraph.children);
+                } else {
+                    self.with_tag(Tag::Paragraph, &paragraph.children)
+                }
+            }
+            mdast::Node::Heading(heading) => {
+                let level =
+                    HeadingLevel::try_from(heading.depth as usize).unwrap_or(HeadingLevel::H6);
+                let tag = Tag::Heading {
+                    level,
+                    id: None,
+                    classes: Vec::new(),
+                    attrs: Vec::new(),
+                };
+                self.with_tag(tag, &heading.children)
+            }
+            mdast::Node::Blockquote(block) => self.with_tag(Tag::BlockQuote(None), &block.children),
+            mdast::Node::List(list) => {
+                let start = if list.ordered {
+                    Some(list.start.unwrap_or(1) as u64)
+                } else {
+                    None
+                };
+                self.with_tag(Tag::List(start), &list.children)
+            }
+            mdast::Node::ListItem(item) => {
+                self.events.push(Event::Start(Tag::Item));
+                if let Some(checked) = item.checked {
+                    self.events.push(Event::TaskListMarker(checked));
+                }
+                let is_tight = !item.spread;
+                if is_tight {
+                    self.tight_list_depth += 1;
+                }
+                self.visit_children(&item.children);
+                if is_tight {
+                    self.tight_list_depth -= 1;
+                }
+                self.events.push(Event::End(Tag::Item.to_end()));
+            }
+            mdast::Node::ThematicBreak(_) => self.events.push(Event::Rule),
+            mdast::Node::Code(code) => {
+                let tag = Tag::CodeBlock(
+                    match &code.lang {
+                        Some(lang) => TagCodeBlockKind::fenced(lang),
+                        None => TagCodeBlockKind::indented(),
+                    }
+                    .into_kind(),
+                );
+                self.events.push(Event::Start(tag.clone()));
+                self.events
+                    .push(Event::Text(CowStr::from(code.value.clone())));
+                self.events.push(Event::End(tag.to_end()));
+            }
+            mdast::Node::Text(text) => {
+                self.events
+                    .push(Event::Text(CowStr::from(text.value.clone())));
+            }
+            mdast::Node::Emphasis(emphasis) => self.with_tag(Tag::Emphasis, &emphasis.children),
+            mdast::Node::Strong(strong) => self.with_tag(Tag::Strong, &strong.children),
+            mdast::Node::Delete(delete) => self.with_tag(Tag::Strikethrough, &delete.children),
+            mdast::Node::InlineCode(code) => {
+                self.events
+                    .push(Event::Code(CowStr::from(code.value.clone())));
+            }
+            mdast::Node::InlineMath(math) => {
+                self.events
+                    .push(Event::InlineMath(CowStr::from(math.value.clone())));
+            }
+            mdast::Node::Math(math) => {
+                self.events
+                    .push(Event::DisplayMath(CowStr::from(math.value.clone())));
+            }
+            mdast::Node::Break(_) => self.events.push(Event::HardBreak),
+            mdast::Node::Link(link) => self.handle_link(link),
+            mdast::Node::Image(image) => self.handle_image(image),
+            mdast::Node::Html(html) => {
+                self.events
+                    .push(Event::Html(CowStr::from(html.value.clone())));
+            }
+            mdast::Node::Table(table) => self.handle_table(table),
+            mdast::Node::TableRow(row) => self.with_tag(Tag::TableRow, &row.children),
+            mdast::Node::TableCell(cell) => self.with_tag(Tag::TableCell, &cell.children),
+            mdast::Node::FootnoteDefinition(def) => {
+                let label = CowStr::from(def.identifier.clone());
+                self.with_tag(Tag::FootnoteDefinition(label), &def.children)
+            }
+            mdast::Node::FootnoteReference(reference) => {
+                self.events.push(Event::FootnoteReference(CowStr::from(
+                    reference.identifier.clone(),
+                )));
+            }
+            mdast::Node::LinkReference(link) => self.handle_link_reference(link),
+            mdast::Node::ImageReference(image) => self.handle_image_reference(image),
+            // Default: keep walking children so nested inline nodes still render.
+            other => {
+                if let Some(children) = other.children() {
+                    self.visit_children(children);
+                }
+            }
+        }
+    }
+
+    fn visit_children(&mut self, children: &[mdast::Node]) {
+        for child in children {
+            self.visit(child);
+        }
+    }
+
+    fn with_tag(&mut self, tag: Tag<'static>, children: &[mdast::Node]) {
+        let end = tag.to_end();
+        self.events.push(Event::Start(tag));
+        self.visit_children(children);
+        self.events.push(Event::End(end));
+    }
+
+    fn handle_link(&mut self, link: &mdast::Link) {
+        let tag = Tag::Link {
+            link_type: LinkType::Inline,
+            dest_url: CowStr::from(link.url.clone()),
+            title: link
+                .title
+                .clone()
+                .map_or(CowStr::Borrowed(""), CowStr::from),
+            id: CowStr::from(String::new()),
+        };
+        self.with_tag(tag, &link.children);
+    }
+
+    fn handle_image(&mut self, image: &mdast::Image) {
+        let tag = Tag::Image {
+            link_type: LinkType::Inline,
+            dest_url: CowStr::from(image.url.clone()),
+            title: image
+                .title
+                .clone()
+                .map_or(CowStr::Borrowed(""), CowStr::from),
+            id: CowStr::from(String::new()),
+        };
+        self.events.push(Event::Start(tag.clone()));
+        if !image.alt.is_empty() {
+            self.events
+                .push(Event::Text(CowStr::from(image.alt.clone())));
+        }
+        self.events.push(Event::End(tag.to_end()));
+    }
+
+    fn handle_table(&mut self, table: &mdast::Table) {
+        let alignments: Vec<Alignment> = table
+            .align
+            .iter()
+            .map(|align| match align {
+                mdast::AlignKind::Left => Alignment::Left,
+                mdast::AlignKind::Right => Alignment::Right,
+                mdast::AlignKind::Center => Alignment::Center,
+                mdast::AlignKind::None => Alignment::None,
+            })
+            .collect();
+        self.with_tag(Tag::Table(alignments), &table.children);
+    }
+
+    fn handle_link_reference(&mut self, link: &mdast::LinkReference) {
+        let tag = Tag::Link {
+            link_type: LinkType::Reference,
+            dest_url: CowStr::from(String::new()),
+            title: CowStr::Borrowed(""),
+            id: CowStr::from(link.identifier.clone()),
+        };
+        self.with_tag(tag, &link.children);
+    }
+
+    fn handle_image_reference(&mut self, image: &mdast::ImageReference) {
+        let tag = Tag::Image {
+            link_type: LinkType::Reference,
+            dest_url: CowStr::from(String::new()),
+            title: CowStr::Borrowed(""),
+            id: CowStr::from(image.identifier.clone()),
+        };
+        self.events.push(Event::Start(tag.clone()));
+        if !image.alt.is_empty() {
+            self.events
+                .push(Event::Text(CowStr::from(image.alt.clone())));
+        }
+        self.events.push(Event::End(tag.to_end()));
+    }
+}
+
+/// Helper for constructing `CodeBlockKind` without leaking pulldown internals
+/// into the recursive builder logic.
+struct TagCodeBlockKind<'a>(pulldown_cmark::CodeBlockKind<'a>);
+
+impl<'a> TagCodeBlockKind<'a> {
+    fn indented() -> Self {
+        Self(pulldown_cmark::CodeBlockKind::Indented)
+    }
+
+    fn fenced(lang: &str) -> Self {
+        Self(pulldown_cmark::CodeBlockKind::Fenced(CowStr::from(
+            lang.to_owned(),
+        )))
+    }
+
+    fn into_kind(self) -> pulldown_cmark::CodeBlockKind<'static> {
+        self.0.into_static()
+    }
+}

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -48,7 +48,7 @@ pub fn parse(input: String) -> napi::Result<String> {
 /// Parses markdown string to HTML with custom rewrite options
 #[napi]
 pub fn parse_with_options(input: String, config: RewriteConfig) -> napi::Result<String> {
-    let events = markflow_core::get_event_iterator(&input);
+    let events = markflow_core::get_event_iterator(&input).map_err(convert_error)?;
     let options: RewriteOptions = config.into();
     let rewriter = StreamingRewriter::new(Vec::new(), options);
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,17 @@
+# Markflow Documentation
+
+Welcome to the Markflow documentation.
+
+## Documentation Index
+
+### Architecture
+- [Architecture Overview](./architecture/overview.md) - High-level system architecture and design principles
+
+### Development
+- [Development Guidelines](./development/guidelines.md) - Repository guidelines and coding standards (English)
+- [開発ガイドライン](./development/guidelines-ja.md) - リポジトリガイドラインとコーディング規約（日本語）
+
+## Project Resources
+
+- [TODO.md](../TODO.md) - Development roadmap and task tracking
+- [README.md](../README.md) - Project overview

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,50 @@
+# Architecture Overview
+
+> This document provides a high-level overview of Markflow's architecture.
+
+## System Architecture
+
+Markflow is a streaming Markdown/MDX engine built with Rust, designed for high-performance processing in web frameworks.
+
+### Core Components
+
+1. **Core Engine** (`crates/core`)
+   - Markdown-rs based parser
+   - Pull-to-push pipeline adapter (PipeAdapter)
+   - Streaming rewriter hooks
+   - No AST materialization for memory efficiency
+
+2. **NAPI Bindings** (`crates/napi`)
+   - Node.js interface via NAPI-RS
+   - Zero-copy streaming to JavaScript
+   - Benchmark comparisons with remark
+
+3. **WASM Bindings** (`crates/wasm`)
+   - WebAssembly interface
+   - Browser and edge runtime support
+
+## Data Flow
+
+```
+Markdown Input
+     ↓
+  Parser (markdown-rs)
+     ↓ (pull-based events)
+  PipeAdapter (pull → push)
+     ↓ (streaming)
+  lol_html Rewriter
+     ↓
+  HTML Output
+```
+
+## Design Principles
+
+- **Streaming-first**: Process content without full AST materialization
+- **Memory efficiency**: Direct streaming without intermediate buffers
+- **Performance**: Target sub-100ms processing for 10MB files
+- **Extensibility**: Plugin-based rewriter hooks
+
+## References
+
+- Full implementation roadmap: [TODO.md](../../TODO.md)
+- Development guidelines: [guidelines.md](../development/guidelines.md)

--- a/docs/development/guidelines-ja.md
+++ b/docs/development/guidelines-ja.md
@@ -15,10 +15,5 @@ Rust 2021 のデフォルトに従い、インデントは 4 スペース、フ�
 ## テストとベンチマーク
 ユニットテストはコード付近（`mod tests`）に置き、入力は `fixtures/` から取得します。ストリーミング／リグレッションのカバレッジには巨大スナップショットではなく Criterion ベンチを使い、ピーク RSS を `benchmarks/results.md` に記録します。Node バインディングは `crates/napi/__tests__/` 配下に AVA/Vitest の `<feature>.spec.ts` を追加します。`core::parser` では 85% 以上のカバレッジを目指し、リライトルールを追加するたびにベンチを用意してください。
 
-## 実装ロードマップ（Phase 1 抜粋）
-- Core Parser Implementation
-  - [ ] `markdown-rs` の導入
-  - [ ] Markdown 基本機能の検証
-
 ## コミットと PR ワークフロー
 Conventional Commits（例: `feat: parser events`, `perf: glue rss drop`）を使用します。全ての PR に summary、TODO.md で影響を受けたタスク、パフォーマンスエビデンス（ベンチ結果またはメモリグラフ）、`node scripts/smoke-napi.mjs` の検証手順を含めます。関連 Issue を参照し、必要に応じて CLI 出力のスクリーンショットを添付します。lint/test を省略する PR やシークレットを含む PR は拒否し、`.env.local` と `dotenvy` を利用してください。

--- a/docs/development/guidelines.md
+++ b/docs/development/guidelines.md
@@ -1,0 +1,19 @@
+# Repository Guidelines
+
+## Project Structure & Workspace
+Phase 1 assumes a Cargo workspace with `crates/core`, `crates/napi`, and `crates/wasm`. Core owns the markdown-rs pipeline plus PipeAdapter, while bindings only expose interfaces. Place benchmarks and profiling data in `benchmarks/`, large Markdown fixtures in `fixtures/markdown/`, and helper scripts in `scripts/` (chmod +x). Keep PRDs or diagrams in `docs/` so architecture conversations stay versioned.
+
+## Build, Test, and Development Commands
+Use `cargo fmt` and `cargo clippy --workspace --all-targets` before pushing. Validate the Rust engine via `cargo test --workspace` and `cargo bench -p markflow-core --features bench` to watch memory when processing 10 MB samples. The Node bridge flow is `pnpm install`, `pnpm run build:napi`, then `node scripts/smoke-napi.mjs samples/large.md` to compare against remark using `console.time`.
+
+## Parser & Glue Expectations
+When extending Task 1.2, keep parser changes as event iterators—no AST materialization. PipeAdapter (Task 1.3) must implement `std::io::Write` and stream directly into `lol_html` without temporary buffers; document any allocation hotspots in code comments. Rewriter hooks (Task 1.4) should prove value with concrete examples such as auto-injecting `loading="lazy"` on `<img>`.
+
+## Coding Style & Naming
+Follow Rust 2021 defaults: 4-space indent, snake_case files, CamelCase types. Adapter implementations live in `*_adapter.rs`; rewriters in `*_rewriter.rs`. Enable `#![deny(missing_docs)]` per crate and describe how each struct participates in the pull→push pipeline. Prefer ESM with named exports on the JS side and keep filenames lowercase-hyphenated.
+
+## Testing & Benchmarks
+Unit tests sit beside code (`mod tests`) and draw inputs from `fixtures/`. For streaming/regression coverage, add Criterion benches rather than huge snapshots, and record peak RSS in `benchmarks/results.md`. Node bindings should gain AVA/Vitest specs under `crates/napi/__tests__/` named `<feature>.spec.ts`. Aim for >85 % coverage inside `core::parser` and add a benchmark for each new rewrite rule.
+
+## Commit & PR Workflow
+Use Conventional Commits (`feat: parser events`, `perf: glue rss drop`). Every PR must include: summary, affected tasks from TODO.md, perf evidence (bench result or memory graph), and instructions for verifying `node scripts/smoke-napi.mjs`. Reference linked issues and attach screenshots for CLI output when relevant. Reject PRs that skip lint/test sections or introduce secrets; rely on `.env.local` with `dotenvy`.


### PR DESCRIPTION
## Summary

This PR replaces the default parsing engine from `pulldown-cmark` to `markdown-rs`. This is a
  foundational change to align with the Master Plan's goal of strict CommonMark/GFM compliance and future AST capabilities.

## Tasks from TODO.md
- [ ] Task 1.x: ...

## Performance Evidence
## Verification Steps
1. `npm install && npm run build:napi`
2. `node scripts/smoke-napi.mjs samples/large.md`
3. Result: ...

## Checklist
- [ ] `cargo fmt` executed?
- [ ] `cargo clippy` passed?
- [ ] Tests passed?
- [ ] No secrets included?
