### PR TITLE
Switch to jsx output

### DIFF
--- a/crates/core/src/renderer/jsx_renderer.rs
+++ b/crates/core/src/renderer/jsx_renderer.rs
@@ -1,7 +1,8 @@
 #![allow(missing_docs)]
 use crate::event::{CodeBlockKind, Event, Tag, TagEnd};
 use crate::{
-    DirectiveAdapter, MarkflowError, ParseResult, RewriteOptions, get_event_iterator, parse,
+    DirectiveAdapter, HoistAdapter, MarkflowError, ParseResult, RewriteOptions, get_event_iterator,
+    parse,
 };
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -10,7 +11,11 @@ use std::rc::Rc;
 pub fn render_to_jsx(input: &str) -> Result<String, MarkflowError> {
     let ParseResult { html: _, imports } = parse(input)?;
     let rewrite_options = RewriteOptions::default();
-    let events = get_event_iterator(input)?;
+    let hoisted = Rc::new(RefCell::new(Vec::new()));
+    let mut events: Box<dyn Iterator<Item = Event<'static>>> = Box::new(get_event_iterator(input)?);
+    if rewrite_options.enable_hoist {
+        events = Box::new(HoistAdapter::new(events, Rc::clone(&hoisted)));
+    }
     let events = DirectiveAdapter::new(
         events,
         Rc::new(RefCell::new(0)),

--- a/crates/napi/src/compiler.rs
+++ b/crates/napi/src/compiler.rs
@@ -1,7 +1,7 @@
 //! The stateful compiler and its configuration.
 
 use crate::types::*;
-use markflow_core::{MarkflowError, RewriteOptions};
+use markflow_core::{MarkflowError, RewriteOptions, render_to_jsx};
 use napi_derive::napi;
 use std::path::Path;
 
@@ -95,6 +95,15 @@ pub fn compile_ir(
 
     let parse_result = markflow_core::parse_with_options(&raw_body, RewriteOptions::default())
         .map_err(super::convert_error)?;
+    let mut jsx = render_to_jsx(&raw_body).map_err(super::convert_error)?;
+    let import_prefix_len: usize = parse_result
+        .imports
+        .iter()
+        .map(|spec| spec.source.len() + 1)
+        .sum();
+    if import_prefix_len > 0 && jsx.len() >= import_prefix_len {
+        jsx = jsx[import_prefix_len..].to_string();
+    }
 
     let headings = super::collect_headings(&raw_body, file_type)?;
     let layout_import: Option<String> = frontmatter
@@ -105,7 +114,7 @@ pub fn compile_ir(
     let frontmatter_json = serde_json::to_string(&frontmatter).unwrap_or_else(|_| "{}".to_string());
 
     Ok(CompileIrResult {
-        html: parse_result.html,
+        html: jsx,
         hoisted_imports: parse_result
             .imports
             .into_iter()

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -18,8 +18,6 @@ pub mod compiler;
 pub mod types;
 pub use types::*;
 
-const ASTRO_RENDER_HELPERS: &str = "astro/runtime/server/render/index.js";
-
 /// Parses markdown string to HTML with default options
 #[napi]
 pub fn parse(input: String) -> napi::Result<String> {
@@ -208,20 +206,9 @@ fn generate_module_code_from_ir(
     let mut code = String::new();
     writeln!(
         code,
-        "import {{ createComponent, markHTMLString }} from '{}';",
-        ir.runtime_import
+        "import {{ Fragment as _Fragment, jsx as _jsx }} from 'astro/jsx-runtime';"
     )
     .map_err(|err| Error::from_reason(err.to_string()))?;
-
-    if ir.layout_import.is_some() {
-        writeln!(
-            code,
-            "import {{ renderComponentToString }} from '{}';",
-            ASTRO_RENDER_HELPERS
-        )
-        .map_err(|err| Error::from_reason(err.to_string()))?;
-    }
-
     if let Some(layout) = ir.layout_import.as_deref() {
         writeln!(code, "import Layout from {};", js_string_literal(layout))
             .map_err(|err| Error::from_reason(err.to_string()))?;
@@ -230,15 +217,6 @@ fn generate_module_code_from_ir(
     for import in hoisted_imports {
         writeln!(code, "{}", import).map_err(|err| Error::from_reason(err.to_string()))?;
     }
-
-    writeln!(
-        code,
-        "const _html = `{}`;",
-        escape_template_literal(&ir.html)
-    )
-    .map_err(|err| Error::from_reason(err.to_string()))?;
-    writeln!(code, "const _markflowHtml = markHTMLString(_html);")
-        .map_err(|err| Error::from_reason(err.to_string()))?;
 
     writeln!(code, "export const frontmatter = {};", ir.frontmatter_json)
         .map_err(|err| Error::from_reason(err.to_string()))?;
@@ -266,39 +244,39 @@ fn generate_module_code_from_ir(
         .map_err(|err| Error::from_reason(err.to_string()))?;
     writeln!(code, "}}").map_err(|err| Error::from_reason(err.to_string()))?;
 
-    writeln!(
-        code,
-        "const _MarkflowContent = createComponent(async () => _markflowHtml);"
-    )
-    .map_err(|err| Error::from_reason(err.to_string()))?;
+    writeln!(code, "function MarkflowContent(props) {{")
+        .map_err(|err| Error::from_reason(err.to_string()))?;
+    writeln!(code, "  return (").map_err(|err| Error::from_reason(err.to_string()))?;
+    writeln!(code, "    <>").map_err(|err| Error::from_reason(err.to_string()))?;
+    code.push_str(&ir.html);
+    if !ir.html.ends_with('\n') {
+        code.push('\n');
+    }
+    writeln!(code, "    </>").map_err(|err| Error::from_reason(err.to_string()))?;
+    writeln!(code, "  );").map_err(|err| Error::from_reason(err.to_string()))?;
+    writeln!(code, "}}").map_err(|err| Error::from_reason(err.to_string()))?;
+
+    writeln!(code, "export const Content = MarkflowContent;")
+        .map_err(|err| Error::from_reason(err.to_string()))?;
 
     if ir.layout_import.is_some() {
+        writeln!(code, "function MarkflowPage(props) {{")
+            .map_err(|err| Error::from_reason(err.to_string()))?;
+        writeln!(code, "  return (").map_err(|err| Error::from_reason(err.to_string()))?;
         writeln!(
             code,
-            "const _MarkflowPage = createComponent(async (result, props, slots) => {{"
+            "    <Layout {{...props}} frontmatter={{frontmatter}}>"
         )
         .map_err(|err| Error::from_reason(err.to_string()))?;
-        writeln!(
-            code,
-            "  const html = await renderComponentToString(result, 'Layout', Layout, {{ ...props, frontmatter }}, {{")
-        .map_err(|err| Error::from_reason(err.to_string()))?;
-        writeln!(
-            code,
-            "    'default': () => _MarkflowContent(result, props, slots)"
-        )
-        .map_err(|err| Error::from_reason(err.to_string()))?;
-        writeln!(code, "  }});").map_err(|err| Error::from_reason(err.to_string()))?;
-        writeln!(code, "  return markHTMLString(html);")
+        writeln!(code, "      <MarkflowContent {{...props}} />")
             .map_err(|err| Error::from_reason(err.to_string()))?;
-        writeln!(code, "}});").map_err(|err| Error::from_reason(err.to_string()))?;
-        writeln!(code, "export const Content = _MarkflowContent;")
-            .map_err(|err| Error::from_reason(err.to_string()))?;
-        writeln!(code, "export default _MarkflowPage;")
+        writeln!(code, "    </Layout>").map_err(|err| Error::from_reason(err.to_string()))?;
+        writeln!(code, "  );").map_err(|err| Error::from_reason(err.to_string()))?;
+        writeln!(code, "}}").map_err(|err| Error::from_reason(err.to_string()))?;
+        writeln!(code, "export default MarkflowPage;")
             .map_err(|err| Error::from_reason(err.to_string()))?;
     } else {
-        writeln!(code, "export const Content = _MarkflowContent;")
-            .map_err(|err| Error::from_reason(err.to_string()))?;
-        writeln!(code, "export default _MarkflowContent;")
+        writeln!(code, "export default MarkflowContent;")
             .map_err(|err| Error::from_reason(err.to_string()))?;
     }
 
@@ -371,13 +349,6 @@ fn build_import_list(layout: Option<&str>, filepath: &Path) -> Vec<ImportedModul
         });
     }
     imports
-}
-
-fn escape_template_literal(value: &str) -> String {
-    value
-        .replace('\\', "\\\\")
-        .replace('`', "\\`")
-        .replace("${", "\\${")
 }
 
 fn js_string_literal(value: &str) -> String {
@@ -483,14 +454,17 @@ mod tests {
         let result =
             crate::compiler::compile_document(&config, source, "test.mdx".into(), None, Vec::new())
                 .expect("compile success");
+        let content_pos = result.code.find("function MarkflowContent").unwrap();
+        let hoist_pos = result.code.find("import X from './x';").unwrap();
         assert!(
-            result.code.contains("import X from './x';"),
-            "code missing hoisted import: {}",
+            hoist_pos < content_pos,
+            "import should be hoisted before JSX content: {}",
             result.code
         );
-        assert!(
-            !result.code.contains("const _html = `import X from './x';`"),
-            "import leaked into HTML template: {}",
+        assert_eq!(
+            result.code.matches("import X from './x';").count(),
+            1,
+            "hoisted import should not appear in JSX body: {}",
             result.code
         );
     }
@@ -502,14 +476,22 @@ mod tests {
         let result =
             crate::compiler::compile_document(&config, source, "test.mdx".into(), None, Vec::new())
                 .expect("compile success");
+        let content_pos = result.code.find("function MarkflowContent").unwrap();
+        let fenced_pos = result.code.find("import Y from './y'").unwrap();
         assert!(
-            !result.code.contains("import Y from './y'"),
-            "fenced import should not hoist: {}",
+            fenced_pos > content_pos,
+            "fenced import should remain in JSX body: {}",
+            result.code
+        );
+        assert_eq!(
+            result.code.matches("import Y from './y'").count(),
+            1,
+            "fenced import should not be hoisted: {}",
             result.code
         );
         assert!(
-            result.code.contains("import Y from &#39;./y&#39;"),
-            "fenced import should remain in rendered HTML: {}",
+            result.code.contains("<pre><code") && result.code.contains("import Y from './y'"),
+            "fenced import should stay in rendered JSX: {}",
             result.code
         );
     }
@@ -523,32 +505,27 @@ mod tests {
         let result =
             crate::compiler::compile_document(&config, source, "test.mdx".into(), None, Vec::new())
                 .expect("compile success");
+        let content_pos = result.code.find("function MarkflowContent").unwrap();
 
-        // hoisted exports appear before _html declaration
+        // hoisted exports appear before JSX content
         let hoist_pos = result.code.find("export const foo").unwrap();
-        let html_pos = result.code.find("const _html = `").unwrap();
         assert!(
-            hoist_pos < html_pos,
-            "exports should be hoisted before HTML: {}",
+            hoist_pos < content_pos,
+            "exports should be hoisted before JSX content: {}",
+            result.code
+        );
+        assert_eq!(
+            result.code.matches("export const foo").count(),
+            1,
+            "hoisted exports should not appear in JSX body: {}",
             result.code
         );
 
-        // exports should not leak into HTML template
+        // default export body hoisted, not in JSX
+        let default_pos = result.code.find("export default function bar()").unwrap();
         assert!(
-            !result.code.contains("const _html = `export const foo"),
-            "exports leaked into HTML: {}",
-            result.code
-        );
-
-        // default export body hoisted, not in HTML
-        assert!(
-            result.code.contains("export default function bar()"),
-            "default export missing: {}",
-            result.code
-        );
-        assert!(
-            !result.code.contains("bar()\\n{\\n  return foo();\\n}\\n"),
-            "default export text appeared in HTML: {}",
+            default_pos < content_pos,
+            "default export should be hoisted before JSX content: {}",
             result.code
         );
     }
@@ -560,17 +537,22 @@ mod tests {
         let result =
             crate::compiler::compile_document(&config, source, "test.mdx".into(), None, Vec::new())
                 .expect("compile success");
-
+        let content_pos = result.code.find("function MarkflowContent").unwrap();
+        let hoisted_pos = result.code.find("export const yes = true;").unwrap();
+        let fenced_pos = result.code.find("export const no = true").unwrap();
         assert!(
-            result.code.contains("export const yes = true;"),
+            hoisted_pos < content_pos,
             "export outside fence should hoist: {}",
             result.code
         );
         assert!(
-            result
-                .code
-                .contains("const _html = `<pre><code>export const no = true</code></pre>"),
-            "fenced export should stay in HTML: {}",
+            fenced_pos > content_pos,
+            "fenced export should stay in JSX body: {}",
+            result.code
+        );
+        assert!(
+            result.code.contains("<pre><code") && result.code.contains("export const no = true"),
+            "fenced export should stay in rendered JSX: {}",
             result.code
         );
     }
@@ -584,25 +566,26 @@ mod tests {
         let result =
             crate::compiler::compile_document(&config, source, "test.mdx".into(), None, Vec::new())
                 .expect("compile success");
-
-        let html_pos = result.code.find("const _html = `").unwrap();
+        let content_pos = result.code.find("function MarkflowContent").unwrap();
         assert!(
-            result.code.find("export default async () => {").unwrap() < html_pos,
+            result.code.find("export default async () => {").unwrap() < content_pos,
             "default async export should be hoisted"
         );
         assert!(
-            result.code.find("export * from './mod';").unwrap() < html_pos,
+            result.code.find("export * from './mod';").unwrap() < content_pos,
             "export * should be hoisted"
         );
         assert!(
-            result.code.find("export const foo = 1 // inline").unwrap() < html_pos,
+            result.code.find("export const foo = 1 // inline").unwrap() < content_pos,
             "inline comment export should be hoisted"
         );
-        assert!(
-            !result
+        assert_eq!(
+            result
                 .code
-                .contains("export const foo = 1 // inline\\n# Title"),
-            "export should not leak into HTML: {}",
+                .matches("export const foo = 1 // inline")
+                .count(),
+            1,
+            "inline export should not appear in JSX body: {}",
             result.code
         );
     }

--- a/crates/napi/src/types.rs
+++ b/crates/napi/src/types.rs
@@ -118,7 +118,7 @@ pub struct CompileResult {
 #[napi(object)]
 #[derive(Debug, Clone)]
 pub struct CompileIrResult {
-    /// Rendered HTML output.
+    /// Rendered JSX output (string form).
     pub html: String,
     /// Hoisted imports/exports captured during parsing (structured).
     pub hoisted_imports: Vec<ImportSpec>,

--- a/docs/decisions/2025-12-25-jsx-output.md
+++ b/docs/decisions/2025-12-25-jsx-output.md
@@ -1,0 +1,31 @@
+# 2025-12-25: JSX output in NAPI codegen
+
+## Decision
+- The Rust compiler returns JSX source (string) instead of HTML for Astro integration.
+- `generate_module_code_from_ir` emits JSX function components and embeds JSX body as code, not as a string literal.
+- The generated module includes `import { Fragment as _Fragment, jsx as _jsx } from 'astro/jsx-runtime';`.
+- `markHTMLString` / `createComponent` are not used in JSX mode.
+- JSON AST-based performance optimization is deferred to a future improvement task.
+
+## Rationale
+- JSX keeps Astro components evaluatable at runtime and avoids tight coupling to Astro internal HTML APIs.
+
+## Status
+- Accepted.
+
+## Follow-up
+- Vite virtual modules should use a `.markflow.jsx` suffix so the JSX output is parsed as JSX.
+- Vite virtual module IDs use `.markflow.jsx`, and `load` returns `meta: { vite: { jsx: true } }` to force JSX parsing.
+- Always emit `import { Fragment as _Fragment, jsx as _jsx } from 'astro/jsx-runtime';` before hoisted imports; do not include `jsxs` / `jsxDEV`.
+- Vite `configResolved` fills `esbuild.jsx="automatic"` and `esbuild.jsxImportSource="astro"` when unset (unless `esbuild` is `false`).
+- JSX 出力の初期確認は `cargo test -p markflow-napi` の既存テスト結果に依存し、追加テストは行わない（2025-12-25）。
+- JSON AST 化によるパフォーマンス最適化は将来タスクとして記録し、現段階では実装しない。
+
+## Implemented in
+- crates/napi/src/lib.rs
+- crates/napi/src/compiler.rs
+- crates/core/src/renderer/jsx_renderer.rs
+- packages/vite-plugin-markflow/src/index.js
+- docs/specs/mf-172-jsx-layout-integration.md
+- docs/specs/mf-173-astro-plugin-harness.md
+- docs/specs/mf-170-markdown-to-jsx.md

--- a/docs/specs/mf-170-markdown-to-jsx.md
+++ b/docs/specs/mf-170-markdown-to-jsx.md
@@ -10,8 +10,10 @@
 - JSX escaping rules for text nodes (current minimal escape: `& < > { }`).
 - How to surface options (e.g., runtime imports, layout wrapping) while keeping a streaming interface.
 - Alignment with NAPI/WASM bindings (naming and return shape).
+- Whether to serialize a JSON AST for performance (deferred).
 
 ## Next Steps
 - Define renderer API surface (options struct, return type).
 - Enumerate fixtures for JSX-in-markdown edge cases (props, children, spread, comments, fragments).
 - Decide on HTML/JSX interop rules (when to `dangerouslySetInnerHTML` vs. literal text).
+- Track JSON AST serialization as a future optimization task.

--- a/docs/specs/mf-172-jsx-layout-integration.md
+++ b/docs/specs/mf-172-jsx-layout-integration.md
@@ -37,7 +37,12 @@ Specify how Markdown→JSX output is wrapped with layout/components, including p
     ```
   - If no layout: `export default Content;`
 - Runtime helpers:
-  - Keep existing runtime imports (`createComponent`, etc.) out-of-scope for this spec; defer to MF-150/JSX runtime spec.
+  - Emit `import { Fragment as _Fragment, jsx as _jsx } from 'astro/jsx-runtime';` at the top of the module.
+  - Do not use `markHTMLString`/`createComponent` in JSX mode.
+  - Keep the runtime import before any hoisted imports/exports.
+  - Limit runtime symbols to `_Fragment` and `_jsx` (no `jsxs` / `jsxDEV`).
+- IR payload:
+  - `CompileIrResult.html` holds the JSX source string (name retained for compatibility).
 - Slots/children:
   - Only `default` slot is supported in this phase; nested/ named slots are out-of-scope.
 - Hoisted imports:

--- a/docs/specs/mf-173-astro-plugin-harness.md
+++ b/docs/specs/mf-173-astro-plugin-harness.md
@@ -24,11 +24,16 @@ Plan how to wire the updated NAPI/WASM JSX renderer into the Astro plugin, and v
 - `escapeHtml` (boolean, default: true) — text escaping flag passed through.
 - `useWasm` (boolean, default: false) — switch between NAPI and WASM backend.
 - `trace` (boolean, default: false) — emit timing/logs for harness comparisons.
+- Vite JSX handling:
+  - Virtual module IDs use a `.markflow.jsx` suffix to ensure JSX parsing.
+  - The `load` hook sets `meta: { vite: { jsx: true } }` on compiled modules.
+  - `configResolved` fills `esbuild.jsx="automatic"` and `esbuild.jsxImportSource="astro"` only when unset (and `esbuild` is not `false`).
 
 ## Harness Validation Plan
 - `scripts/run-astro-harness.mjs` で baseline / markflow をビルド。`compare-astro-harness.mjs` はビルド時間を記録するのみ（HTML diff なし）。
 - 必要に応じて dev モードの手動比較やセマンティック diff を追加実装する。
 - 回帰ポイント: directive hydration、frontmatter layout、auto-imported components、コードフェンス内 import。
+- JSX 出力の初期確認は `markflow-napi` の既存テストに依存し、新規テストは現段階では追加しない。
 
 ## withastro/docs Rollout Plan (staged)
 1) **Preview subset**: apply plugin to a small folder (e.g., `/en/getting-started`), feature-flag via `renderToJsx` option.

--- a/packages/vite-plugin-markflow/src/index.js
+++ b/packages/vite-plugin-markflow/src/index.js
@@ -103,6 +103,19 @@ export function markflowPlugin(userOptions = {}) {
     enforce: "pre",
     async configResolved(config) {
       resolvedConfig = config;
+      if (config.esbuild == null) {
+        config.esbuild = {
+          jsx: "automatic",
+          jsxImportSource: "astro",
+        };
+      } else if (config.esbuild !== false) {
+        if (config.esbuild.jsx == null) {
+          config.esbuild.jsx = "automatic";
+        }
+        if (config.esbuild.jsxImportSource == null) {
+          config.esbuild.jsxImportSource = "astro";
+        }
+      }
       const binding = providedBinding ?? (await loadMarkflowBinding());
       const createCompiler = binding.createCompiler
         ? binding.createCompiler
@@ -143,7 +156,7 @@ export function markflowPlugin(userOptions = {}) {
         resolved && resolved.id
           ? stripQuery(unwrapVirtual(resolved.id))
           : fallback();
-      const virtualId = `${VIRTUAL_PREFIX}${resolvedId}.markflow`;
+      const virtualId = `${VIRTUAL_PREFIX}${resolvedId}.markflow.jsx`;
       sourceLookup.set(virtualId, resolvedId);
       return virtualId;
     },
@@ -155,7 +168,8 @@ export function markflowPlugin(userOptions = {}) {
         throw new Error("Markflow compiler has not been initialized");
       }
       const filename =
-        sourceLookup.get(id) ?? stripQuery(id.slice(VIRTUAL_PREFIX.length));
+        sourceLookup.get(id) ??
+        stripQuery(id.slice(VIRTUAL_PREFIX.length).replace(/\.markflow\.jsx$/, ""));
       const source = await readFile(filename, "utf8");
       const fileOptions = deriveFileOptions(filename, resolvedConfig?.root);
       const result = compiler.compile(source, filename, fileOptions);
@@ -169,6 +183,11 @@ export function markflowPlugin(userOptions = {}) {
       return {
         code: result.code,
         map: result.map ?? undefined,
+        meta: {
+          vite: {
+            jsx: true,
+          },
+        },
       };
     },
   };


### PR DESCRIPTION
## Summary

- Switch Markflow output from HTML strings to JSX function components so Astro components execute at runtime.

## Changes

- Generate JSX in Rust and embed JSX code directly in module output (crates/napi/src/compiler.rs, crates/napi/src/lib.rs, crates/core/src/renderer/jsx_renderer.rs, crates/napi/src/types.rs).
- Ensure Vite treats virtual modules as JSX (.markflow.jsx, meta.vite.jsx, and esbuild defaults)(packages/vite-plugin-markflow/src/index.js).
- Update specs and add decision log (docs/specs/mf-170-markdown-to-jsx.md, docs/specs/mf-172-jsx-layout-integration.md, docs/specs/mf-173-astro-plugin-harness.md, docs/decisions/2025-12-25-jsx-output.md).

## Testing

- cargo test -p markflow-napi