### PR TITLE
Streaming multipass

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -32,8 +32,8 @@ pub use error::MarkflowError;
 pub use frontmatter::{FrontmatterError, FrontmatterExtraction, extract_frontmatter};
 pub use parser::{ParseConfig, ParseConstructs};
 pub use renderer::{
-    ComponentRegistry, JsxComponentPlugin, JsxElement, JsxOptions, RenderContext, RenderOutcome,
-    RewriteOptions, StreamingRewriter, render_to_jsx, render_to_jsx_with_options,
+    ComponentRegistry, JsxComponentPlugin, JsxOptions, JsxStreamRenderer, RenderContext,
+    RenderOutcome, RewriteOptions, StreamingRewriter, render_to_jsx, render_to_jsx_with_options,
 };
 pub use slug::{Slugger, slugify};
 pub use span::Span;

--- a/crates/core/src/renderer/jsx.rs
+++ b/crates/core/src/renderer/jsx.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs)]
 use crate::event::{CodeBlockKind, Event, HeadingLevel, Tag, TagEnd};
-use crate::renderer::multipass::{Block, scan_iter};
+use crate::renderer::multipass::{ScanEvent, scan_iter};
 use crate::transform::code_fence::collect_root_imports;
 use crate::{DirectiveAdapter, HoistAdapter, MarkflowError, RewriteOptions, get_event_iterator};
 use std::cell::RefCell;
@@ -9,9 +9,7 @@ use std::fmt::Write as FmtWrite;
 use std::rc::Rc;
 
 mod components;
-pub use components::{
-    ComponentRegistry, JsxComponentPlugin, JsxElement, RenderContext, RenderOutcome,
-};
+pub use components::{ComponentRegistry, JsxComponentPlugin, RenderContext, RenderOutcome};
 
 /// Options for JSX rendering.
 #[derive(Default)]
@@ -37,9 +35,11 @@ pub fn render_to_jsx_with_options(
     let mut seen_imports = HashSet::new();
     let (root_imports, _body_lines) = collect_root_imports(input);
     let ctx = RenderContext::new(&rewrite_options, &components);
+    let mut renderer = JsxStreamRenderer::new(ctx);
     let mut body = String::with_capacity(input.len());
-    for block in scan_iter(input) {
-        render_block_into(&block, &ctx, &mut body)?;
+    let mut stream = scan_iter(input);
+    while let Some(event) = stream.next() {
+        renderer.render_event(event, &mut stream, &mut body)?;
     }
 
     let mut output = String::with_capacity(body.len() + input.len());
@@ -175,75 +175,81 @@ fn render_markdown_events(
     Ok(())
 }
 
-fn render_block_into(
-    block: &Block<'_>,
-    ctx: &RenderContext<'_>,
-    output: &mut String,
-) -> Result<(), MarkflowError> {
-    match block {
-        Block::Markdown(text) => render_markdown_events(text, ctx.rewrite_options, output),
-        Block::Code(text) => render_markdown_events(text, ctx.rewrite_options, output),
-        Block::JsxElement {
-            name,
-            attrs,
-            children,
-            is_self_closing,
-        } => {
-            let rendered_attrs = render_attrs(attrs, *is_self_closing);
-            let element = JsxElement {
+pub struct JsxStreamRenderer<'a> {
+    ctx: RenderContext<'a>,
+    depth: usize,
+}
+
+impl<'a> JsxStreamRenderer<'a> {
+    pub fn new(ctx: RenderContext<'a>) -> Self {
+        Self { ctx, depth: 0 }
+    }
+
+    pub fn child(&self) -> Self {
+        Self {
+            ctx: self.ctx,
+            depth: self.depth + 1,
+        }
+    }
+
+    pub fn require_import(&self, import: impl Into<String>) {
+        self.ctx.require_import(import);
+    }
+
+    pub fn render_markdown(&self, input: &str, output: &mut String) -> Result<(), MarkflowError> {
+        if self.depth == 0 {
+            return render_markdown_events(input, self.ctx.rewrite_options, output);
+        }
+
+        let mut dedented = input.to_string();
+        for _ in 0..self.depth {
+            dedented = dedent_one_level(&dedented);
+        }
+        render_markdown_events(&dedented, self.ctx.rewrite_options, output)
+    }
+
+    pub fn render_event(
+        &mut self,
+        event: ScanEvent<'a>,
+        stream: &mut dyn Iterator<Item = ScanEvent<'a>>,
+        output: &mut String,
+    ) -> Result<(), MarkflowError> {
+        match event {
+            ScanEvent::Markdown { text, .. } => self.render_markdown(text, output),
+            ScanEvent::Code { text, .. } => self.render_markdown(text, output),
+            ScanEvent::JsxOpen {
                 name,
                 attrs,
-                children,
-                is_self_closing: *is_self_closing,
-            };
-            if *is_self_closing {
-                let mut scratch = String::new();
-                let _ = ctx
-                    .components
-                    .render_children(&element, ctx, &mut scratch)?;
+                is_self_closing,
+                ..
+            } => {
+                let components = self.ctx.components;
+                if components.render_stream(&event, stream, self, output)? {
+                    return Ok(());
+                }
+                let rendered_attrs = render_attrs(attrs, is_self_closing);
                 output.push('<');
                 output.push_str(name);
                 output.push_str(&rendered_attrs);
-                output.push_str(" />");
-            } else {
-                output.push('<');
-                output.push_str(name);
-                output.push_str(&rendered_attrs);
-                output.push('>');
-                if !ctx.components.render_children(&element, ctx, output)? {
-                    render_jsx_children_into(children, ctx, output)?;
+                if is_self_closing {
+                    output.push_str(" />");
+                } else {
+                    output.push('>');
+                    self.depth = self.depth.saturating_add(1);
+                }
+                Ok(())
+            }
+            ScanEvent::JsxClose { name, .. } => {
+                if self.depth > 0 {
+                    self.depth -= 1;
                 }
                 output.push_str("</");
                 output.push_str(name);
                 output.push('>');
-            }
-            Ok(())
-        }
-    }
-}
-
-fn render_jsx_children_into(
-    children: &[Block<'_>],
-    ctx: &RenderContext<'_>,
-    output: &mut String,
-) -> Result<(), MarkflowError> {
-    for child in children {
-        match child {
-            Block::Markdown(text) => {
-                let dedented = dedent_one_level(text);
-                render_markdown_events(&dedented, ctx.rewrite_options, output)?;
-            }
-            Block::Code(text) => {
-                let dedented = dedent_one_level(text);
-                render_markdown_events(&dedented, ctx.rewrite_options, output)?;
-            }
-            _ => {
-                render_block_into(child, ctx, output)?;
+                Ok(())
             }
         }
     }
-
-    Ok(())
 }
 
 fn dedent_one_level(input: &str) -> String {

--- a/crates/core/src/renderer/jsx/components.rs
+++ b/crates/core/src/renderer/jsx/components.rs
@@ -1,24 +1,11 @@
 use std::collections::HashMap;
 
-use super::{
-    Block, MarkflowError, RewriteOptions, dedent_one_level, render_block_into,
-    render_markdown_events,
-};
+use crate::renderer::multipass::ScanEvent;
 
-/// Lightweight view of a JSX element emitted by the multipass scanner.
-#[derive(Debug, Clone, Copy)]
-pub struct JsxElement<'a> {
-    /// Element tag name.
-    pub name: &'a str,
-    /// Raw attribute string from the source.
-    pub attrs: &'a str,
-    /// Child blocks for the element.
-    pub children: &'a [Block<'a>],
-    /// Whether the element is self-closing.
-    pub is_self_closing: bool,
-}
+use super::{JsxStreamRenderer, MarkflowError, RewriteOptions};
 
 /// Shared context passed to JSX component plugins.
+#[derive(Clone, Copy)]
 pub struct RenderContext<'a> {
     pub(super) rewrite_options: &'a RewriteOptions,
     pub(super) components: &'a ComponentRegistry,
@@ -42,29 +29,6 @@ impl<'a> RenderContext<'a> {
             .borrow_mut()
             .push(import.into());
     }
-
-    /// Renders nested blocks using the same component registry.
-    pub fn render_children(
-        &self,
-        children: &[Block<'_>],
-        output: &mut String,
-    ) -> Result<(), MarkflowError> {
-        super::render_jsx_children_into(children, self, output)
-    }
-
-    /// Renders a single block using the same component registry.
-    pub fn render_block(
-        &self,
-        block: &Block<'_>,
-        output: &mut String,
-    ) -> Result<(), MarkflowError> {
-        render_block_into(block, self, output)
-    }
-
-    /// Renders Markdown text into HTML using the current rewrite options.
-    pub fn render_markdown(&self, input: &str, output: &mut String) -> Result<(), MarkflowError> {
-        render_markdown_events(input, self.rewrite_options, output)
-    }
 }
 
 /// Outcome of plugin rendering.
@@ -79,11 +43,12 @@ pub enum RenderOutcome {
 pub trait JsxComponentPlugin {
     /// Returns true if the plugin wants to handle the given component name.
     fn matches(&self, name: &str) -> bool;
-    /// Optionally renders the component's children or performs side effects.
-    fn render_children(
+    /// Optionally renders the component stream or performs side effects.
+    fn render_stream<'a>(
         &self,
-        element: &JsxElement<'_>,
-        ctx: &RenderContext<'_>,
+        event: &ScanEvent<'a>,
+        stream: &mut dyn Iterator<Item = ScanEvent<'a>>,
+        renderer: &mut JsxStreamRenderer<'a>,
         output: &mut String,
     ) -> Result<RenderOutcome, MarkflowError>;
 }
@@ -111,32 +76,45 @@ impl ComponentRegistry {
         self.import_map.insert(name.into(), import.into());
     }
 
-    pub(crate) fn render_children(
+    pub(crate) fn render_stream<'a>(
         &self,
-        element: &JsxElement<'_>,
-        ctx: &RenderContext<'_>,
+        event: &ScanEvent<'a>,
+        stream: &mut dyn Iterator<Item = ScanEvent<'a>>,
+        renderer: &mut JsxStreamRenderer<'a>,
         output: &mut String,
     ) -> Result<bool, MarkflowError> {
-        if let Some(import) = self.import_map.get(element.name) {
-            ctx.require_import(import.clone());
+        let ScanEvent::JsxOpen {
+            name,
+            is_self_closing,
+            ..
+        } = event
+        else {
+            return Ok(false);
+        };
+
+        if let Some(import) = self.import_map.get(*name) {
+            renderer.require_import(import.clone());
         }
 
         for plugin in &self.plugins {
-            if plugin.matches(element.name) {
-                match plugin.render_children(element, ctx, output)? {
+            if plugin.matches(name) {
+                let mut child = renderer.child();
+                match plugin.render_stream(event, stream, &mut child, output)? {
                     RenderOutcome::Handled => return Ok(true),
                     RenderOutcome::Skipped => {}
                 }
             }
         }
 
-        match element.name {
-            "Steps" => {
-                render_steps_children(element.children, ctx, output)?;
+        match *name {
+            "Steps" if !*is_self_closing => {
+                let mut child = renderer.child();
+                render_steps_stream(stream, &mut child, output)?;
                 Ok(true)
             }
-            "FileTree" => {
-                render_file_tree_children(element.children, ctx, output)?;
+            "FileTree" if !*is_self_closing => {
+                let mut child = renderer.child();
+                render_file_tree_stream(stream, &mut child, output)?;
                 Ok(true)
             }
             _ => Ok(false),
@@ -144,55 +122,58 @@ impl ComponentRegistry {
     }
 }
 
-fn render_steps_children(
-    children: &[Block<'_>],
-    ctx: &RenderContext<'_>,
+fn render_steps_stream<'a>(
+    stream: &mut dyn Iterator<Item = ScanEvent<'a>>,
+    renderer: &mut JsxStreamRenderer<'a>,
     output: &mut String,
 ) -> Result<(), MarkflowError> {
     let mut scratch = String::new();
-    for child in children {
-        scratch.clear();
-        match child {
-            Block::Markdown(text) => {
-                let dedented = dedent_one_level(text);
-                ctx.render_markdown(&dedented, &mut scratch)?;
+    while let Some(event) = stream.next() {
+        match event {
+            ScanEvent::JsxClose { name: "Steps", .. } => break,
+            ScanEvent::Markdown { .. } => {
+                scratch.clear();
+                renderer.render_event(event, stream, &mut scratch)?;
                 append_steps_fragment(output, &scratch);
             }
             _ => {
-                ctx.render_block(child, &mut scratch)?;
+                scratch.clear();
+                renderer.render_event(event, stream, &mut scratch)?;
                 insert_into_last_list_item(output, &scratch);
             }
         }
     }
-
     Ok(())
 }
 
-fn render_file_tree_children(
-    children: &[Block<'_>],
-    ctx: &RenderContext<'_>,
+fn render_file_tree_stream<'a>(
+    stream: &mut dyn Iterator<Item = ScanEvent<'a>>,
+    renderer: &mut JsxStreamRenderer<'a>,
     output: &mut String,
 ) -> Result<(), MarkflowError> {
     let mut inner = String::new();
     let mut markdown_buffer = String::new();
 
-    for child in children {
-        match child {
-            Block::Markdown(text) => {
-                markdown_buffer.push_str(&dedent_one_level(text));
+    while let Some(event) = stream.next() {
+        match event {
+            ScanEvent::JsxClose {
+                name: "FileTree", ..
+            } => break,
+            ScanEvent::Markdown { text, .. } => {
+                markdown_buffer.push_str(text);
             }
             _ => {
                 if !markdown_buffer.is_empty() {
-                    ctx.render_markdown(&markdown_buffer, &mut inner)?;
+                    renderer.render_markdown(&markdown_buffer, &mut inner)?;
                     markdown_buffer.clear();
                 }
-                ctx.render_block(child, &mut inner)?;
+                renderer.render_event(event, stream, &mut inner)?;
             }
         }
     }
 
     if !markdown_buffer.is_empty() {
-        ctx.render_markdown(&markdown_buffer, &mut inner)?;
+        renderer.render_markdown(&markdown_buffer, &mut inner)?;
     }
 
     output.push_str(&extract_first_unordered_list(&inner));
@@ -318,14 +299,10 @@ fn find_ul_close(bytes: &[u8], start: usize) -> Option<(usize, usize)> {
         {
             let mut end = pos + 4;
             while end < bytes.len() {
-                match bytes[end] {
-                    b'>' => return Some((pos, end + 1 - pos)),
-                    b' ' | b'\t' | b'\n' | b'\r' => {
-                        end += 1;
-                        continue;
-                    }
-                    _ => break,
+                if bytes[end] == b'>' {
+                    return Some((pos, end - pos + 1));
                 }
+                end += 1;
             }
         }
         pos += 1;

--- a/crates/core/src/renderer/mod.rs
+++ b/crates/core/src/renderer/mod.rs
@@ -6,7 +6,7 @@ pub mod multipass;
 pub mod streaming_rewriter;
 
 pub use jsx::{
-    ComponentRegistry, JsxComponentPlugin, JsxElement, JsxOptions, RenderContext, RenderOutcome,
-    render_to_jsx, render_to_jsx_with_options,
+    ComponentRegistry, JsxComponentPlugin, JsxOptions, JsxStreamRenderer, RenderContext,
+    RenderOutcome, render_to_jsx, render_to_jsx_with_options,
 };
 pub use streaming_rewriter::{RewriteOptions, StreamingRewriter};

--- a/crates/core/src/renderer/multipass.rs
+++ b/crates/core/src/renderer/multipass.rs
@@ -1,14 +1,26 @@
 #![allow(missing_docs)]
 
+use crate::Span;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Block<'a> {
-    Markdown(&'a str),
-    Code(&'a str),
-    JsxElement {
+pub enum ScanEvent<'a> {
+    Markdown {
+        text: &'a str,
+        span: Span,
+    },
+    Code {
+        text: &'a str,
+        span: Span,
+    },
+    JsxOpen {
         name: &'a str,
         attrs: &'a str,
-        children: Vec<Block<'a>>,
         is_self_closing: bool,
+        span: Span,
+    },
+    JsxClose {
+        name: &'a str,
+        span: Span,
     },
 }
 
@@ -29,7 +41,7 @@ impl<'a> ScanIter<'a> {
         }
     }
 
-    fn flush_markdown(&mut self) -> Option<Block<'a>> {
+    fn flush_markdown(&mut self) -> Option<ScanEvent<'a>> {
         let start = self.pending_start?;
         let end = self.pending_end;
         self.pending_start = None;
@@ -37,7 +49,10 @@ impl<'a> ScanIter<'a> {
         if start >= end {
             return None;
         }
-        Some(Block::Markdown(&self.input[start..end]))
+        Some(ScanEvent::Markdown {
+            text: &self.input[start..end],
+            span: Span::new(start, end),
+        })
     }
 
     fn extend_markdown(&mut self, start: usize, end: usize) {
@@ -57,7 +72,7 @@ impl<'a> ScanIter<'a> {
 }
 
 impl<'a> Iterator for ScanIter<'a> {
-    type Item = Block<'a>;
+    type Item = ScanEvent<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let bytes = self.input.as_bytes();
@@ -79,16 +94,50 @@ impl<'a> Iterator for ScanIter<'a> {
                     let end_pos = find_byte(bytes, fence_end, b'\n')
                         .map(|newline| newline + 1)
                         .unwrap_or_else(|| self.input.len());
-                    if let Some(block) = self.flush_markdown() {
-                        return Some(block);
+                    if let Some(event) = self.flush_markdown() {
+                        return Some(event);
                     }
-                    let block = Block::Code(&self.input[self.cursor..end_pos]);
+                    let span = Span::new(self.cursor, end_pos);
+                    let event = ScanEvent::Code {
+                        text: &self.input[self.cursor..end_pos],
+                        span,
+                    };
                     self.cursor = end_pos;
-                    return Some(block);
+                    return Some(event);
                 }
                 self.extend_markdown(self.cursor, self.input.len());
                 self.cursor = self.input.len();
                 continue;
+            }
+
+            if bytes.get(self.cursor) == Some(&b'<') {
+                let remaining = &self.input[self.cursor..];
+                if let Some((name, consumed)) = parse_jsx_close(remaining) {
+                    if let Some(event) = self.flush_markdown() {
+                        return Some(event);
+                    }
+                    let start = self.cursor;
+                    let end = start + consumed;
+                    self.cursor = end;
+                    return Some(ScanEvent::JsxClose {
+                        name,
+                        span: Span::new(start, end),
+                    });
+                }
+                if let Some((name, attrs, is_self_closing, consumed)) = parse_jsx_open(remaining) {
+                    if let Some(event) = self.flush_markdown() {
+                        return Some(event);
+                    }
+                    let start = self.cursor;
+                    let end = start + consumed;
+                    self.cursor = end;
+                    return Some(ScanEvent::JsxOpen {
+                        name,
+                        attrs,
+                        is_self_closing,
+                        span: Span::new(start, end),
+                    });
+                }
             }
 
             if bytes.get(self.cursor) == Some(&b'`') {
@@ -133,51 +182,8 @@ impl<'a> Iterator for ScanIter<'a> {
                 continue;
             }
 
-            if self.cursor < bytes.len() && bytes[self.cursor] == b'<' {
-                if let Some((name, attrs, open_end)) = parse_open_tag(self.input, self.cursor) {
-                    if !is_component_tag(name) {
-                        let end = open_end.saturating_add(1);
-                        self.extend_markdown(self.cursor, end);
-                        self.cursor = end;
-                        continue;
-                    }
-                    let is_self_closing = is_self_closing(bytes, self.cursor, open_end);
-                    if is_self_closing {
-                        if let Some(block) = self.flush_markdown() {
-                            return Some(block);
-                        }
-                        let block = Block::JsxElement {
-                            name,
-                            attrs,
-                            children: Vec::new(),
-                            is_self_closing: true,
-                        };
-                        self.cursor = open_end.saturating_add(1);
-                        return Some(block);
-                    }
-                    let (children, new_cursor, closed) =
-                        scan_nodes(self.input, open_end + 1, Some(name));
-                    if closed {
-                        if let Some(block) = self.flush_markdown() {
-                            return Some(block);
-                        }
-                        let block = Block::JsxElement {
-                            name,
-                            attrs,
-                            children,
-                            is_self_closing: false,
-                        };
-                        self.cursor = new_cursor;
-                        return Some(block);
-                    }
-                    self.extend_markdown(self.cursor, self.cursor + 1);
-                    self.cursor += 1;
-                    continue;
-                }
-                self.extend_markdown(self.cursor, self.cursor + 1);
-                self.cursor += 1;
-                continue;
-            }
+            self.extend_markdown(self.cursor, self.cursor + 1);
+            self.cursor += 1;
 
             if self.cursor == prev_cursor {
                 break;
@@ -188,154 +194,12 @@ impl<'a> Iterator for ScanIter<'a> {
     }
 }
 
-pub fn scan(input: &str) -> Vec<Block<'_>> {
+pub fn scan(input: &str) -> Vec<ScanEvent<'_>> {
     ScanIter::new(input).collect()
 }
 
 pub fn scan_iter(input: &str) -> ScanIter<'_> {
     ScanIter::new(input)
-}
-
-fn push_markdown<'a>(blocks: &mut Vec<Block<'a>>, input: &'a str, start: usize, end: usize) {
-    if start >= end {
-        return;
-    }
-
-    // Merge adjacent markdown slices to avoid splitting paragraphs around inline spans.
-    if let Some(Block::Markdown(last)) = blocks.last_mut() {
-        let last_end_addr = last.as_ptr() as usize + last.len();
-        let new_start_addr = input.as_ptr() as usize + start;
-
-        if last_end_addr == new_start_addr {
-            let input_start_addr = input.as_ptr() as usize;
-            let last_start_offset = last.as_ptr() as usize - input_start_addr;
-            *last = &input[last_start_offset..end];
-            return;
-        }
-    }
-
-    blocks.push(Block::Markdown(&input[start..end]));
-}
-
-fn scan_nodes<'a>(
-    input: &'a str,
-    mut cursor: usize,
-    until: Option<&'a str>,
-) -> (Vec<Block<'a>>, usize, bool) {
-    let mut blocks = Vec::new();
-    let bytes = input.as_bytes();
-
-    while cursor < bytes.len() {
-        let prev_cursor = cursor;
-        let line_start = find_line_start(bytes, cursor);
-        if is_fence_start(bytes, line_start).is_some() && cursor != line_start {
-            cursor = line_start;
-        }
-        if let Some(tag_name) = until
-            && is_close_tag(bytes, cursor, tag_name.as_bytes())
-        {
-            if let Some(close_end) = find_tag_end(input, cursor + 2 + tag_name.len()) {
-                return (blocks, close_end.saturating_add(1), true);
-            }
-            return (blocks, cursor, false);
-        }
-        if let Some((marker, count)) = is_fence_start(bytes, cursor) {
-            if let Some(fence_end) = find_fence_end(bytes, cursor + 1, marker, count) {
-                let end_pos = find_byte(bytes, fence_end, b'\n')
-                    .map(|newline| newline + 1)
-                    .unwrap_or_else(|| input.len());
-                blocks.push(Block::Code(&input[cursor..end_pos]));
-                cursor = end_pos;
-                continue;
-            }
-            push_markdown(&mut blocks, input, cursor, cursor + 1);
-            cursor += 1;
-            if cursor < input.len() {
-                push_markdown(&mut blocks, input, cursor, input.len());
-            }
-            return (blocks, input.len(), false);
-        }
-        if bytes.get(cursor) == Some(&b'`') {
-            if let Some(end) = find_inline_code_end(bytes, cursor) {
-                push_markdown(&mut blocks, input, cursor, end);
-                cursor = end;
-            } else {
-                // Treat lone/unclosed backticks as literal text to avoid stalling the scanner.
-                push_markdown(&mut blocks, input, cursor, cursor + 1);
-                cursor += 1;
-            }
-            continue;
-        }
-        let mut next_lt = find_byte(bytes, cursor, b'<');
-        while let Some(pos) = next_lt {
-            let line_start = find_line_start(bytes, pos);
-            if is_fence_start(bytes, line_start).is_some() {
-                next_lt = find_byte(bytes, pos + 1, b'<');
-                continue;
-            }
-            break;
-        }
-        let next_fence = find_fence_start(bytes, cursor);
-        let next_tick = find_byte(bytes, cursor, b'`');
-        let mut next_stop: Option<usize> = None;
-        for pos in [next_lt, next_fence, next_tick].into_iter().flatten() {
-            next_stop = Some(match next_stop {
-                Some(current) => current.min(pos),
-                None => pos,
-            });
-        }
-        if next_stop.is_none() {
-            push_markdown(&mut blocks, input, cursor, input.len());
-            return (blocks, input.len(), false);
-        }
-        let pos = next_stop.unwrap();
-        if cursor < pos {
-            push_markdown(&mut blocks, input, cursor, pos);
-            cursor = pos;
-            continue;
-        }
-        if cursor < bytes.len() && bytes[cursor] == b'<' {
-            if let Some((name, attrs, open_end)) = parse_open_tag(input, cursor) {
-                if !is_component_tag(name) {
-                    let end = open_end.saturating_add(1);
-                    push_markdown(&mut blocks, input, cursor, end);
-                    cursor = end;
-                    continue;
-                }
-                let is_self_closing = is_self_closing(bytes, cursor, open_end);
-                if is_self_closing {
-                    blocks.push(Block::JsxElement {
-                        name,
-                        attrs,
-                        children: Vec::new(),
-                        is_self_closing: true,
-                    });
-                    cursor = open_end.saturating_add(1);
-                    continue;
-                }
-                let (children, new_cursor, closed) = scan_nodes(input, open_end + 1, Some(name));
-                if closed {
-                    blocks.push(Block::JsxElement {
-                        name,
-                        attrs,
-                        children,
-                        is_self_closing: false,
-                    });
-                    cursor = new_cursor;
-                    continue;
-                }
-                push_markdown(&mut blocks, input, cursor, cursor + 1);
-                cursor += 1;
-            } else {
-                push_markdown(&mut blocks, input, cursor, cursor + 1);
-                cursor += 1;
-            }
-        }
-        if cursor == prev_cursor {
-            break;
-        }
-    }
-    (blocks, cursor, false)
 }
 
 fn find_byte(bytes: &[u8], start: usize, target: u8) -> Option<usize> {
@@ -358,67 +222,6 @@ fn find_line_start(bytes: &[u8], pos: usize) -> usize {
         i -= 1;
     }
     i
-}
-
-fn find_tag_end(input: &str, start: usize) -> Option<usize> {
-    find_byte(input.as_bytes(), start, b'>')
-}
-
-fn is_self_closing(bytes: &[u8], open_start: usize, open_end: usize) -> bool {
-    let _ = open_start;
-    if open_end == 0 {
-        return false;
-    }
-    bytes.get(open_end.saturating_sub(1)) == Some(&b'/')
-}
-
-fn is_name_char(byte: u8) -> bool {
-    byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b':' | b'_')
-}
-
-fn is_component_tag(name: &str) -> bool {
-    name.chars()
-        .next()
-        .is_some_and(|ch| ch.is_ascii_uppercase())
-}
-
-fn is_tag_terminator(byte: u8) -> bool {
-    matches!(byte, b' ' | b'\n' | b'\t' | b'\r' | b'/' | b'>')
-}
-
-fn parse_open_tag(input: &str, open_start: usize) -> Option<(&str, &str, usize)> {
-    let bytes = input.as_bytes();
-    let name_start = open_start + 1;
-    let mut name_end = name_start;
-
-    while name_end < bytes.len() && !is_tag_terminator(bytes[name_end]) {
-        if !is_name_char(bytes[name_end]) {
-            return None;
-        }
-        name_end += 1;
-    }
-
-    if name_end == name_start {
-        return None;
-    }
-
-    let open_end = find_tag_end(input, name_end)?;
-    let attrs = input[name_end..open_end].trim();
-    Some((&input[name_start..name_end], attrs, open_end))
-}
-
-fn is_close_tag(bytes: &[u8], pos: usize, name: &[u8]) -> bool {
-    if pos + 2 + name.len() > bytes.len() {
-        return false;
-    }
-    if bytes[pos] != b'<' || bytes[pos + 1] != b'/' {
-        return false;
-    }
-    if &bytes[pos + 2..pos + 2 + name.len()] != name {
-        return false;
-    }
-    let end = pos + 2 + name.len();
-    bytes.get(end).copied().is_some_and(is_tag_terminator)
 }
 
 fn is_line_start(bytes: &[u8], pos: usize) -> bool {
@@ -538,123 +341,185 @@ fn skip_fence_indent(bytes: &[u8], pos: usize) -> Option<usize> {
     Some(i)
 }
 
+fn is_name_char(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b':' | b'_')
+}
+
+fn is_component_tag(name: &str) -> bool {
+    name.chars()
+        .next()
+        .is_some_and(|ch| ch.is_ascii_uppercase())
+}
+
+fn take_name(input: &str) -> Option<(&str, &str)> {
+    let bytes = input.as_bytes();
+    let mut end = 0usize;
+    while end < bytes.len() && is_name_char(bytes[end]) {
+        end += 1;
+    }
+    if end == 0 {
+        return None;
+    }
+    Some((&input[..end], &input[end..]))
+}
+
+fn parse_jsx_close(input: &str) -> Option<(&str, usize)> {
+    let rest = input.strip_prefix("</")?;
+    let (name, rest) = take_name(rest)?;
+    if !is_component_tag(name) {
+        return None;
+    }
+    let rest = rest.trim_start();
+    let rest = rest.strip_prefix('>')?;
+    let consumed = input.len() - rest.len();
+    Some((name, consumed))
+}
+
+fn parse_jsx_open(input: &str) -> Option<(&str, &str, bool, usize)> {
+    let rest = input.strip_prefix('<')?;
+    if rest.starts_with('/') {
+        return None;
+    }
+    let (name, rest) = take_name(rest)?;
+    if !is_component_tag(name) {
+        return None;
+    }
+    let end = rest.find('>')?;
+    let raw_attrs = &rest[..end];
+    let rest = &rest[end + 1..];
+    let trimmed = raw_attrs.trim();
+    let (attrs, is_self_closing) = if let Some(stripped) = trimmed.strip_suffix('/') {
+        (stripped.trim_end(), true)
+    } else {
+        (trimmed, false)
+    };
+    let consumed = input.len() - rest.len();
+    Some((name, attrs, is_self_closing, consumed))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{Block, find_fence_end, is_fence_start, scan};
+    use super::{ScanEvent, find_fence_end, is_fence_start, scan};
 
     #[test]
     fn scan_returns_single_markdown_block() {
         let input = "hello";
-        let blocks = scan(input);
+        let events = scan(input);
 
-        assert_eq!(blocks, vec![Block::Markdown(input)]);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            ScanEvent::Markdown { text, .. } if text == input
+        ));
     }
 
     #[test]
     fn scan_coalesces_inline_code_fragments() {
         let input = "Click `button` now";
-        let blocks = scan(input);
+        let events = scan(input);
 
-        assert_eq!(blocks, vec![Block::Markdown(input)]);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            ScanEvent::Markdown { text, .. } if text == input
+        ));
     }
 
     #[test]
     fn scan_unclosed_inline_code_is_markdown() {
         let input = "Click `button now";
-        let blocks = scan(input);
+        let events = scan(input);
 
-        assert_eq!(blocks, vec![Block::Markdown(input)]);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            ScanEvent::Markdown { text, .. } if text == input
+        ));
     }
 
     #[test]
     fn scan_empty_returns_empty() {
-        let blocks = scan("");
+        let events = scan("");
 
-        assert!(blocks.is_empty());
+        assert!(events.is_empty());
     }
 
     #[test]
     fn scan_emits_self_closing_jsx_element() {
-        let blocks = scan("<Tabs />");
+        let events = scan("<Tabs />");
 
-        assert_eq!(
-            blocks,
-            vec![Block::JsxElement {
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            ScanEvent::JsxOpen {
                 name: "Tabs",
-                attrs: "/",
-                children: Vec::new(),
+                attrs: "",
                 is_self_closing: true,
-            }]
-        );
+                ..
+            }
+        ));
     }
 
     #[test]
     fn scan_emits_jsx_element_with_children() {
-        let blocks = scan("<Steps>hello</Steps>");
+        let events = scan("<Steps>hello</Steps>");
 
-        assert_eq!(
-            blocks,
-            vec![Block::JsxElement {
-                name: "Steps",
-                attrs: "",
-                children: vec![Block::Markdown("hello")],
-                is_self_closing: false,
-            }]
-        );
+        assert!(matches!(
+            events.as_slice(),
+            [
+                ScanEvent::JsxOpen { name: "Steps", .. },
+                ScanEvent::Markdown { text: "hello", .. },
+                ScanEvent::JsxClose { name: "Steps", .. }
+            ]
+        ));
     }
 
     #[test]
     fn scan_keeps_lowercase_html_as_markdown() {
         let input = "<h3>Title</h3>";
-        let blocks = scan(input);
+        let events = scan(input);
 
-        assert_eq!(blocks, vec![Block::Markdown(input)]);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            ScanEvent::Markdown { text, .. } if text == input
+        ));
     }
 
     #[test]
     fn scan_handles_nested_same_tag() {
-        let blocks = scan("<Steps><Steps>inner</Steps>outer</Steps>");
+        let events = scan("<Steps><Steps>inner</Steps>outer</Steps>");
 
-        assert_eq!(
-            blocks,
-            vec![Block::JsxElement {
-                name: "Steps",
-                attrs: "",
-                children: vec![
-                    Block::JsxElement {
-                        name: "Steps",
-                        attrs: "",
-                        children: vec![Block::Markdown("inner")],
-                        is_self_closing: false,
-                    },
-                    Block::Markdown("outer"),
-                ],
-                is_self_closing: false,
-            }]
-        );
+        assert!(matches!(
+            events.as_slice(),
+            [
+                ScanEvent::JsxOpen { name: "Steps", .. },
+                ScanEvent::JsxOpen { name: "Steps", .. },
+                ScanEvent::Markdown { text: "inner", .. },
+                ScanEvent::JsxClose { name: "Steps", .. },
+                ScanEvent::Markdown { text: "outer", .. },
+                ScanEvent::JsxClose { name: "Steps", .. }
+            ]
+        ));
     }
 
     #[test]
     fn scan_ignores_self_closing_in_nested_match() {
-        let blocks = scan("<Steps><Steps />inner</Steps>");
+        let events = scan("<Steps><Steps />inner</Steps>");
 
-        assert_eq!(
-            blocks,
-            vec![Block::JsxElement {
-                name: "Steps",
-                attrs: "",
-                children: vec![
-                    Block::JsxElement {
-                        name: "Steps",
-                        attrs: "/",
-                        children: Vec::new(),
-                        is_self_closing: true,
-                    },
-                    Block::Markdown("inner"),
-                ],
-                is_self_closing: false,
-            }]
-        );
+        assert!(matches!(
+            events.as_slice(),
+            [
+                ScanEvent::JsxOpen { name: "Steps", .. },
+                ScanEvent::JsxOpen {
+                    name: "Steps",
+                    is_self_closing: true,
+                    ..
+                },
+                ScanEvent::Markdown { text: "inner", .. },
+                ScanEvent::JsxClose { name: "Steps", .. }
+            ]
+        ));
     }
 
     #[test]
@@ -683,51 +548,74 @@ mod tests {
     #[test]
     fn scan_emits_code_block_for_fence() {
         let input = "```\n<Steps>\n```";
-        let blocks = scan(input);
+        let events = scan(input);
 
-        assert_eq!(blocks, vec![Block::Code(input)]);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            ScanEvent::Code { text, .. } if text == input
+        ));
     }
 
     #[test]
     fn scan_does_not_parse_jsx_inside_fence() {
         let input = "```\n<Tabs />\n```\n";
-        let blocks = scan(input);
+        let events = scan(input);
 
-        assert_eq!(blocks, vec![Block::Code(input)]);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            ScanEvent::Code { text, .. } if text == input
+        ));
     }
 
     #[test]
     fn scan_continues_after_fence() {
         let input = "```\n<Steps>\n```\n<Tabs />";
-        let blocks = scan(input);
+        let events = scan(input);
 
-        assert_eq!(
-            blocks,
-            vec![
-                Block::Code("```\n<Steps>\n```\n"),
-                Block::JsxElement {
-                    name: "Tabs",
-                    attrs: "/",
-                    children: Vec::new(),
-                    is_self_closing: true,
+        assert!(matches!(
+            events.as_slice(),
+            [
+                ScanEvent::Code {
+                    text: "```\n<Steps>\n```\n",
+                    ..
                 },
+                ScanEvent::JsxOpen {
+                    name: "Tabs",
+                    is_self_closing: true,
+                    ..
+                }
             ]
-        );
+        ));
     }
 
     #[test]
     fn scan_falls_back_on_unclosed_fence() {
         let input = "```\n<Steps>";
-        let blocks = scan(input);
+        let events = scan(input);
 
-        assert_eq!(blocks, vec![Block::Markdown("```\n<Steps>")]);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            ScanEvent::Markdown { text, .. } if text == input
+        ));
     }
 
     #[test]
-    fn scan_falls_back_on_missing_close_tag() {
+    fn scan_emits_open_when_missing_close_tag() {
         let input = "<Steps>no close";
-        let blocks = scan(input);
+        let events = scan(input);
 
-        assert_eq!(blocks, vec![Block::Markdown("<Steps>no close")]);
+        assert!(matches!(
+            events.as_slice(),
+            [
+                ScanEvent::JsxOpen { name: "Steps", .. },
+                ScanEvent::Markdown {
+                    text: "no close",
+                    ..
+                }
+            ]
+        ));
     }
 }

--- a/crates/core/tests/integration_tests.rs
+++ b/crates/core/tests/integration_tests.rs
@@ -1,5 +1,6 @@
+use markflow_core::renderer::multipass::ScanEvent;
 use markflow_core::{
-    ComponentRegistry, JsxComponentPlugin, JsxElement, JsxOptions, MarkflowError, RenderContext,
+    ComponentRegistry, JsxComponentPlugin, JsxOptions, JsxStreamRenderer, MarkflowError,
     RenderOutcome, RewriteOptions, parse, parse_with_options, render_to_jsx,
     render_to_jsx_with_options,
 };
@@ -23,14 +24,26 @@ impl JsxComponentPlugin for BadgePlugin {
         name == "Badge"
     }
 
-    fn render_children(
+    fn render_stream<'a>(
         &self,
-        element: &JsxElement<'_>,
-        ctx: &RenderContext<'_>,
+        event: &ScanEvent<'a>,
+        stream: &mut dyn Iterator<Item = ScanEvent<'a>>,
+        renderer: &mut JsxStreamRenderer<'a>,
         output: &mut String,
     ) -> Result<RenderOutcome, MarkflowError> {
+        let ScanEvent::JsxOpen { name, .. } = event else {
+            return Ok(RenderOutcome::Skipped);
+        };
+        if *name != "Badge" {
+            return Ok(RenderOutcome::Skipped);
+        }
         output.push_str("<span class=\"badge\">");
-        ctx.render_children(element.children, output)?;
+        while let Some(event) = stream.next() {
+            match event {
+                ScanEvent::JsxClose { name: "Badge", .. } => break,
+                _ => renderer.render_event(event, stream, output)?,
+            }
+        }
         output.push_str("</span>");
         Ok(RenderOutcome::Handled)
     }
@@ -62,12 +75,20 @@ fn jsx_registry_allows_imports_and_plugins() {
         "import should be hoisted before the body. output: {output}"
     );
     assert!(
-        output.contains("<span class=\"badge\"><p>Hi</p>"),
-        "plugin output should wrap children. output: {output}"
+        output.contains("<span class=\"badge\">"),
+        "plugin output should include wrapper start. output: {output}"
     );
     assert!(
-        output.contains("</span></Badge>"),
-        "plugin output should remain inside the component. output: {output}"
+        output.contains("<p>Hi</p>"),
+        "plugin output should render children. output: {output}"
+    );
+    assert!(
+        output.contains("</span>"),
+        "plugin output should include wrapper end. output: {output}"
+    );
+    assert!(
+        !output.contains("<Badge>"),
+        "plugin output should replace the original component tag. output: {output}"
     );
 }
 

--- a/docs/specs/mf-170-markdown-to-jsx.md
+++ b/docs/specs/mf-170-markdown-to-jsx.md
@@ -1,6 +1,7 @@
 # MF-170: Markdown → JSX renderer passthrough
 
 > Draft scaffold – fill in API, edge cases, and test plan.
+> Update (2026-01-11): multipass now streams `ScanEvent` (no `Block` tree). The Block/`scan_nodes` details below are historical; see MF-171 for current API notes.
 
 ## Scope
 - Preserve raw JSX/MDX nodes through the Markdown pipeline and emit JSX source suitable for downstream bundlers.

--- a/docs/specs/mf-171-jsx-renderer-api.md
+++ b/docs/specs/mf-171-jsx-renderer-api.md
@@ -11,6 +11,7 @@ Define the Rust/NAPI/WASM API surface and the escaping/serialization rules for t
   - `render_to_jsx_with_options(input: &str, options: JsxOptions) -> Result<String, MarkflowError>`
   - `JsxOptions { rewrite_options: RewriteOptions, components: ComponentRegistry }`
     - `ComponentRegistry` handles built-in JSX components (`Steps`, `FileTree`) plus optional plugins and import mappings.
+    - Plugins now receive a streaming `ScanEvent` iterator via `render_stream`.
 - NAPI:
   - `renderToJsx(input: string, options?: JsxRenderOptions): string`
   - `JsxRenderOptions { rewrite?: RewriteConfig, componentImports?: { name: string, import: string }[] }`
@@ -38,9 +39,10 @@ Define the Rust/NAPI/WASM API surface and the escaping/serialization rules for t
 \* Table cell alignment attributes are not yet emitted in JSX mode (future work).
 
 ## Multipass Integration (current)
-- `render_to_jsx` scans input with the multipass `Block` tree, renders `Block::Markdown` via the event pipeline, and emits `Block::JsxElement` directly.
-- `Block::Code` is rendered through the event pipeline so fenced code becomes `<pre><code>`, while still skipping JSX scanning inside fences.
-- `<Steps>` renders Markdown children first, then injects non-Markdown siblings before the last `</li>` (or appends if no list item exists).
+- `render_to_jsx` consumes a streaming `ScanEvent` iterator (`Markdown`, `Code`, `JsxOpen`, `JsxClose`) instead of building a `Block` tree.
+- `ScanEvent::Code` is rendered through the event pipeline so fenced code becomes `<pre><code>`, while still skipping JSX scanning inside fences.
+- `JsxOpen`/`JsxClose` events are streamed; component plugins can consume until their matching close tag.
+- `<Steps>` renders Markdown fragments first, then injects non-Markdown fragments before the last `</li>` (or appends if no list item exists).
 
 ## Escaping Policy (current)
 - Escape only text nodes: `& < > { }` → `&amp; &lt; &gt; &#123; &#125;`.


### PR DESCRIPTION
## Summary

  - Replace the multipass Block tree with a streaming ScanEvent iterator (Markdown | Code | JsxOpen | JsxClose).
  - Refactor JSX renderer to consume the stream and introduce JsxStreamRenderer (no recursive block rendering).
  - Redesign plugin API to render_stream, update built-ins (Steps/FileTree) to stream-consume children.
  - Update docs to reflect the new streaming pipeline and behavior.

  ## Behavior Changes (Breaking)

  - JSX processing is now event-stream based; plugins are invoked on JsxOpen and consume until the matching
    JsxClose.
  - Unclosed JSX tags emit JsxOpen + trailing Markdown (no fallback to full Markdown block).
  - Custom components handled by plugins no longer preserve the original <Tag>...</Tag> wrapper unless the plugin
    writes it.

  ## Tests

  - cargo fmt --all
  - cargo clippy --workspace --all-targets -- -D warnings
  - cargo test --workspace

  ## Notes

  - This is the full Phase 3.3 streaming pivot (O(1) memory, no children: Vec<Block> buffering).
  - Docs updated: docs/specs/mf-170-markdown-to-jsx.md, docs/specs/mf-171-jsx-renderer-api.md.