### PR TITLE
handle user-provided export default statements

### DIFF
--- a/crates/napi/src/codegen.rs
+++ b/crates/napi/src/codegen.rs
@@ -84,15 +84,18 @@ pub(crate) fn generate_module_code_from_ir(
     writeln!(code, "export const Content = MarkflowContent;")
         .map_err(|err| Error::from_reason(err.to_string()))?;
 
-    if ir.layout_import.is_some() {
-        writeln!(
-            code,
-            "export default createComponent((result, props) => renderJSX(result, _jsx(Layout, {{...props, frontmatter: frontmatter, children: _jsx(MarkflowContent, {{...props}})}})), file);"
-        )
-        .map_err(|err| Error::from_reason(err.to_string()))?;
-    } else {
-        writeln!(code, "export default MarkflowContent;")
+    // Only generate export default if user didn't provide their own
+    if !ir.has_user_default_export {
+        if ir.layout_import.is_some() {
+            writeln!(
+                code,
+                "export default createComponent((result, props) => renderJSX(result, _jsx(Layout, {{...props, frontmatter: frontmatter, children: _jsx(MarkflowContent, {{...props}})}})), file);"
+            )
             .map_err(|err| Error::from_reason(err.to_string()))?;
+        } else {
+            writeln!(code, "export default MarkflowContent;")
+                .map_err(|err| Error::from_reason(err.to_string()))?;
+        }
     }
 
     Ok(code)

--- a/crates/napi/src/compiler.rs
+++ b/crates/napi/src/compiler.rs
@@ -51,12 +51,15 @@ fn count_braces(line: &str) -> i32 {
 
 /// Splits leading import/export statements from the document body.
 /// Supports multi-line statements via brace tracking.
-fn split_leading_imports(input: &str) -> (Vec<String>, String) {
+/// Returns (hoisted_statements, body, has_user_default_export).
+fn split_leading_imports(input: &str) -> (Vec<String>, String, bool) {
     let mut hoisted = Vec::new();
     let mut lines = Vec::new();
     let mut collecting = true;
     let mut pending_statement: Option<String> = None;
     let mut brace_depth = 0i32;
+    let mut has_user_default_export = false;
+    let mut pending_is_default = false;
 
     for line in input.lines() {
         // Continue collecting multi-line statement
@@ -66,7 +69,11 @@ fn split_leading_imports(input: &str) -> (Vec<String>, String) {
             brace_depth += count_braces(line);
 
             if brace_depth <= 0 {
+                if pending_is_default {
+                    has_user_default_export = true;
+                }
                 hoisted.push(pending_statement.take().unwrap());
+                pending_is_default = false;
             }
             continue;
         }
@@ -78,13 +85,18 @@ fn split_leading_imports(input: &str) -> (Vec<String>, String) {
                 continue;
             }
             if trimmed.starts_with("import ") || trimmed.starts_with("export ") {
+                let is_default = trimmed.starts_with("export default");
                 brace_depth = count_braces(line);
 
                 if brace_depth > 0 {
                     // Multi-line statement - start collecting
                     pending_statement = Some(line.to_string());
+                    pending_is_default = is_default;
                 } else {
                     // Single-line statement
+                    if is_default {
+                        has_user_default_export = true;
+                    }
                     hoisted.push(line.to_string());
                 }
                 continue;
@@ -104,7 +116,7 @@ fn split_leading_imports(input: &str) -> (Vec<String>, String) {
         lines.join("\n")
     };
 
-    (hoisted, body)
+    (hoisted, body, has_user_default_export)
 }
 
 #[derive(Debug, Clone)]
@@ -240,7 +252,8 @@ pub fn compile_ir(
 
     // Extract leading imports/exports before mdast processing
     // mdast doesn't handle ESM imports yet, so we extract them manually
-    let (leading_imports, body_without_imports) = split_leading_imports(&raw_body);
+    let (leading_imports, body_without_imports, has_user_default_export) =
+        split_leading_imports(&raw_body);
 
     // Use mdast pipeline to generate blocks
     let mdast_options = MdastOptions {
@@ -297,6 +310,7 @@ pub fn compile_ir(
         layout_import,
         runtime_import: internal.jsx_import_source,
         diagnostics,
+        has_user_default_export,
     })
 }
 

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -421,7 +421,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // TODO: export default conflicts with generated `export default MarkflowContent`
     fn compile_document_hoists_exports_variants() {
         let config = InternalCompilerConfig::new(None);
         let source = "\nexport const foo = () => {\n  return 1\n}\n\nexport default function bar()\n{\n  return foo();\n}\n\nexport { foo };\n\n\n# Title"
@@ -482,7 +481,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // TODO: export default conflicts with generated `export default MarkflowContent`
     fn compile_document_hoists_export_edge_cases() {
         let config = InternalCompilerConfig::new(None);
         let source = "\nexport default async () => {\n  return 1\n}\n\nexport * from './mod';\n\nexport const foo = 1 // inline\n\n\n# Title"

--- a/crates/napi/src/types.rs
+++ b/crates/napi/src/types.rs
@@ -193,6 +193,8 @@ pub struct CompileIrResult {
     pub runtime_import: String,
     /// Parse diagnostics (warnings, not errors)
     pub diagnostics: Diagnostics,
+    /// Whether user provided their own `export default` statement.
+    pub has_user_default_export: bool,
 }
 
 /// Structured import returned by the compiler IR.


### PR DESCRIPTION
## Summary

When users write `export default` in their MDX files, it conflicted with the auto-generated `export default MarkflowContent`:

```javascript
// User's MDX:
export default function MyLayout({ children }) {
  return <main>{children}</main>
}

# Content

// Previously broken output:
export default function MyLayout({ children }) { ... }  // hoisted
// ...
export default MarkflowContent;  // ← CONFLICT! Two default exports
```

This PR fixes the issue by tracking whether the user provided their own `export default` and conditionally skipping the auto-generated one.

## Changes

- **`compiler.rs`**: `split_leading_imports()` now returns a `has_user_default_export` flag
- **`types.rs`**: Add `has_user_default_export: bool` to `CompileIrResult`
- **`codegen.rs`**: Conditionally skip `export default MarkflowContent` generation
- **`lib.rs`**: Enable 2 previously ignored tests

## Test Plan

- [x] Enabled and verified `compile_document_hoists_exports_variants` test passes
- [x] Enabled and verified `compile_document_hoists_export_edge_cases` test passes
- [x] All 113 workspace tests pass
- [x] `cargo fmt` and `cargo clippy` pass