### PR TITLE
Add astro-code class and tabindex to code blocks

### DIFF
--- a/crates/core/src/renderer/mdast.rs
+++ b/crates/core/src/renderer/mdast.rs
@@ -542,8 +542,10 @@ fn render_node(node: &Node, ctx: &mut Context) {
         }
 
         // Code block node - render as <pre><code>
+        // astro-code class for Starlight CSS compatibility
+        // tabindex="0" for keyboard accessibility when horizontally scrolling
         Node::Code(code) => {
-            ctx.push_raw("<pre>");
+            ctx.push_raw(r#"<pre class="astro-code" tabindex="0">"#);
 
             // Language class for syntax highlighting
             if let Some(lang) = &code.lang {

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -371,7 +371,8 @@ mod tests {
             result.code
         );
         assert!(
-            result.code.contains("<pre><code") && result.code.contains("import Y from './y'"),
+            result.code.contains(r#"<pre class="astro-code""#)
+                && result.code.contains("import Y from './y'"),
             "fenced import should stay in rendered JSX: {}",
             result.code
         );
@@ -474,7 +475,8 @@ mod tests {
             result.code
         );
         assert!(
-            result.code.contains("<pre><code") && result.code.contains("export const no = true"),
+            result.code.contains(r#"<pre class="astro-code""#)
+                && result.code.contains("export const no = true"),
             "fenced export should stay in rendered JSX: {}",
             result.code
         );


### PR DESCRIPTION
## Summary

Code Block (`<pre><code>`) に Starlight 互換の属性を追加。

**変更前:**
```html
<pre><code class="language-rust">fn main() {}</code></pre>
```

**変更後:**
```html
<pre class="astro-code" tabindex="0"><code class="language-rust">fn main() {}</code></pre>
```

## Changes

- **`mdast.rs`**: `<pre>` タグに `class="astro-code"` と `tabindex="0"` を追加
- **`lib.rs`**: テストのアサーションを更新

## Why

1. **`class="astro-code"`** - Starlight の CSS が適用されるために必須
2. **`tabindex="0"`** - 横スクロール時のキーボードアクセシビリティ対応

## Test Plan

- [x] 全113テストパス
- [x] `cargo fmt` / `cargo clippy` パス