### PR TITLE
feat(wasm): add compile() function for Astro module generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,6 +446,7 @@ dependencies = [
  "markflow-core",
  "serde",
  "serde-wasm-bindgen",
+ "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-test",
 ]

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -10,6 +10,7 @@ wasm-bindgen = { workspace = true }
 markflow-core = { path = "../core" }
 js-sys = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 serde-wasm-bindgen = "0.6"
 
 [dev-dependencies]

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -1,9 +1,244 @@
 use js_sys::Function;
+use markflow_core::MdastOptions;
 use markflow_core::code_fence::collect_root_imports;
+use markflow_core::renderer::mdast::{RenderBlock, to_blocks};
 use markflow_core::{MarkdownStream, RewriteOptions, StreamingRewriter, get_event_iterator};
+use serde::Serialize;
+use std::fmt::Write as FmtWrite;
 use std::io::{self, Write};
 use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::*;
+
+// ============================================================================
+// Compile API Types
+// ============================================================================
+
+/// Heading metadata extracted from the document.
+#[derive(Debug, Clone, Serialize)]
+pub struct HeadingEntry {
+    /// Heading depth (1-6).
+    pub depth: u8,
+    /// Slugified identifier.
+    pub slug: String,
+    /// Visible heading text.
+    pub text: String,
+}
+
+/// Result of compiling MDX to an Astro-compatible module.
+#[derive(Debug, Clone, Serialize)]
+pub struct CompileResult {
+    /// Generated JavaScript/JSX module code.
+    pub code: String,
+    /// Serialized frontmatter as JSON string.
+    pub frontmatter_json: String,
+    /// Extracted heading metadata.
+    pub headings: Vec<HeadingEntry>,
+    /// Whether the user provided their own export default.
+    pub has_user_default_export: bool,
+}
+
+// ============================================================================
+// Compile API
+// ============================================================================
+
+/// Compiles MDX source into an Astro-compatible JavaScript module.
+///
+/// This function extracts frontmatter, hoists imports/exports, parses markdown
+/// to JSX, and generates a complete module with createComponent wrapper.
+///
+/// # Arguments
+///
+/// * `source` - The MDX source code
+/// * `filepath` - File path for error messages and `export const file`
+///
+/// # Returns
+///
+/// Returns a JavaScript object with:
+/// - `code`: The generated module code
+/// - `frontmatter_json`: Serialized frontmatter
+/// - `headings`: Array of heading metadata
+/// - `has_user_default_export`: Whether user provided export default
+#[wasm_bindgen]
+pub fn compile(source: &str, filepath: &str) -> Result<JsValue, JsError> {
+    // 1. Extract frontmatter
+    let frontmatter_extraction = markflow_core::extract_frontmatter(source)
+        .map_err(|e| JsError::new(&format!("Frontmatter error: {}", e)))?;
+    let frontmatter = frontmatter_extraction.value;
+    let raw_body = &source[frontmatter_extraction.body_start..];
+
+    // 2. Extract imports/exports from entire document
+    let (hoisted_imports, body_lines) = collect_root_imports(raw_body);
+    let body_without_imports = body_lines.join("\n");
+    let has_user_default_export = hoisted_imports
+        .iter()
+        .any(|s| s.trim_start().starts_with("export default"));
+
+    // 3. Parse to blocks and render JSX
+    let mdast_options = MdastOptions {
+        inject_starlight_css: false,
+        enable_directives: true,
+    };
+    let blocks_result = to_blocks(&body_without_imports, &mdast_options)
+        .map_err(|e| JsError::new(&format!("Parse error: {}", e)))?;
+
+    let jsx_body = blocks_to_jsx_string(&blocks_result.blocks);
+
+    // 4. Convert headings
+    let headings: Vec<HeadingEntry> = blocks_result
+        .headings
+        .into_iter()
+        .map(|h| HeadingEntry {
+            depth: h.depth,
+            slug: h.slug,
+            text: h.text,
+        })
+        .collect();
+
+    // 5. Serialize data
+    let frontmatter_json = serde_json::to_string(&frontmatter).unwrap_or_else(|_| "{}".to_string());
+    let headings_json = serde_json::to_string(&headings).unwrap_or_else(|_| "[]".to_string());
+
+    // 6. Generate module code
+    let code = generate_module_code(
+        &jsx_body,
+        &hoisted_imports,
+        &frontmatter_json,
+        &headings_json,
+        filepath,
+        has_user_default_export,
+    );
+
+    // 7. Build result
+    let result = CompileResult {
+        code,
+        frontmatter_json,
+        headings,
+        has_user_default_export,
+    };
+
+    serde_wasm_bindgen::to_value(&result)
+        .map_err(|e| JsError::new(&format!("Serialization error: {}", e)))
+}
+
+/// Converts RenderBlocks to a JSX string.
+fn blocks_to_jsx_string(blocks: &[RenderBlock]) -> String {
+    let mut result = String::new();
+    for block in blocks {
+        match block {
+            RenderBlock::Html { content } => {
+                result.push_str(content);
+            }
+            RenderBlock::Component {
+                name,
+                props,
+                slot_html,
+            } => {
+                result.push('<');
+                result.push_str(name);
+
+                // Render props as {...{key: "value", ...}}
+                if !props.is_empty() {
+                    result.push_str(" {...{");
+                    let mut first = true;
+                    for (key, value) in props {
+                        if !first {
+                            result.push_str(", ");
+                        }
+                        first = false;
+                        result.push('"');
+                        result.push_str(&key.replace('"', "\\\""));
+                        result.push_str("\": \"");
+                        result.push_str(&value.replace('"', "\\\"").replace('\n', "\\n"));
+                        result.push('"');
+                    }
+                    result.push_str("}}");
+                }
+
+                result.push('>');
+                result.push_str(slot_html);
+                result.push_str("</");
+                result.push_str(name);
+                result.push('>');
+            }
+        }
+    }
+    result
+}
+
+/// Generates Astro-compatible module code.
+fn generate_module_code(
+    jsx: &str,
+    hoisted_imports: &[String],
+    frontmatter_json: &str,
+    headings_json: &str,
+    filepath: &str,
+    has_user_default_export: bool,
+) -> String {
+    let mut code = String::new();
+
+    // Runtime imports
+    let _ = writeln!(
+        code,
+        "import {{ Fragment, jsx as __jsx }} from 'astro/jsx-runtime';"
+    );
+    let _ = writeln!(code, "const _Fragment = Fragment;");
+    let _ = writeln!(
+        code,
+        "const _jsx = (type, props, ...children) => {{\n  const resolved = props ?? {{}};\n  if (children.length > 0) {{\n    resolved.children = children.length === 1 ? children[0] : children;\n  }}\n  return __jsx(type, resolved, resolved.key);\n}};"
+    );
+    let _ = writeln!(
+        code,
+        "import {{ createComponent, renderJSX }} from 'astro/runtime/server/index.js';"
+    );
+
+    // Hoisted imports
+    for import in hoisted_imports {
+        let _ = writeln!(code, "{}", import);
+    }
+
+    // Exports
+    let _ = writeln!(code, "export const frontmatter = {};", frontmatter_json);
+    let _ = writeln!(code, "export const file = {};", js_string_literal(filepath));
+    let _ = writeln!(code, "export const url = undefined;");
+    let _ = writeln!(code, "export const headings = {};", headings_json);
+    let _ = writeln!(code, "export function getHeadings() {{");
+    let _ = writeln!(code, "  return {};", headings_json);
+    let _ = writeln!(code, "}}");
+
+    // MarkflowContent component
+    let _ = writeln!(code, "// function MarkflowContent");
+    let _ = writeln!(
+        code,
+        "const MarkflowContent = createComponent((result, props) => {{"
+    );
+    let _ = writeln!(code, "  return renderJSX(result, (");
+    let _ = writeln!(code, "    <>");
+    code.push_str(jsx);
+    if !jsx.ends_with('\n') {
+        code.push('\n');
+    }
+    let _ = writeln!(code, "    </>");
+    let _ = writeln!(code, "  ));");
+    let _ = writeln!(code, "}}, file);");
+
+    let _ = writeln!(code, "export const Content = MarkflowContent;");
+
+    // Export default (conditional)
+    if !has_user_default_export {
+        let _ = writeln!(code, "export default MarkflowContent;");
+    }
+
+    code
+}
+
+/// Converts a string to a JavaScript string literal.
+fn js_string_literal(value: &str) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_string())
+}
+
+// ============================================================================
+// Existing Render API
+// ============================================================================
 
 /// Renders markdown into an HTML `String`.
 #[wasm_bindgen(js_name = render_html)]

--- a/crates/wasm/tests/compile.rs
+++ b/crates/wasm/tests/compile.rs
@@ -1,0 +1,114 @@
+use markflow_wasm::compile;
+use serde::Deserialize;
+use wasm_bindgen_test::*;
+
+#[derive(Deserialize, Debug)]
+struct CompileResult {
+    code: String,
+    frontmatter_json: String,
+    headings: Vec<HeadingEntry>,
+    has_user_default_export: bool,
+}
+
+#[derive(Deserialize, Debug)]
+struct HeadingEntry {
+    depth: u8,
+    slug: String,
+    text: String,
+}
+
+#[wasm_bindgen_test]
+fn compile_basic_markdown() {
+    let source = "# Hello World\n\nThis is **bold** text.";
+    let result = compile(source, "test.mdx").expect("compile should succeed");
+
+    let result: CompileResult = serde_wasm_bindgen::from_value(result).expect("deserialize result");
+
+    // Check code generation
+    assert!(result.code.contains("import { Fragment, jsx as __jsx }"));
+    assert!(result.code.contains("createComponent"));
+    assert!(result.code.contains("export const frontmatter"));
+    assert!(result.code.contains("export default MarkflowContent"));
+
+    // Check headings extracted
+    assert_eq!(result.headings.len(), 1);
+    assert_eq!(result.headings[0].depth, 1);
+    assert_eq!(result.headings[0].slug, "hello-world");
+    assert_eq!(result.headings[0].text, "Hello World");
+
+    // Check frontmatter (empty)
+    assert_eq!(result.frontmatter_json, "{}");
+
+    // No user default export
+    assert!(!result.has_user_default_export);
+}
+
+#[wasm_bindgen_test]
+fn compile_with_frontmatter() {
+    let source = "---\ntitle: My Page\ndraft: true\n---\n\n# Content";
+    let result = compile(source, "page.mdx").expect("compile should succeed");
+
+    let result: CompileResult = serde_wasm_bindgen::from_value(result).expect("deserialize result");
+
+    // Check frontmatter is extracted
+    assert!(result.frontmatter_json.contains("\"title\""));
+    assert!(result.frontmatter_json.contains("My Page"));
+    assert!(result.frontmatter_json.contains("\"draft\""));
+
+    // Check code exports frontmatter
+    assert!(result.code.contains("export const frontmatter ="));
+}
+
+#[wasm_bindgen_test]
+fn compile_with_imports() {
+    let source = "import Button from './Button.astro';\n\n# Hello\n\n<Button />";
+    let result = compile(source, "test.mdx").expect("compile should succeed");
+
+    let result: CompileResult = serde_wasm_bindgen::from_value(result).expect("deserialize result");
+
+    // Check import is hoisted
+    assert!(result.code.contains("import Button from './Button.astro'"));
+
+    // Heading still extracted
+    assert_eq!(result.headings.len(), 1);
+}
+
+#[wasm_bindgen_test]
+fn compile_with_user_default_export() {
+    let source = "export default function Layout({ children }) { return children; }\n\n# Hello";
+    let result = compile(source, "test.mdx").expect("compile should succeed");
+
+    let result: CompileResult = serde_wasm_bindgen::from_value(result).expect("deserialize result");
+
+    // User provided default export
+    assert!(result.has_user_default_export);
+
+    // Should NOT have our default export
+    assert!(!result.code.contains("export default MarkflowContent"));
+}
+
+#[wasm_bindgen_test]
+fn compile_multiple_headings() {
+    let source = "# First\n\n## Second\n\n### Third\n\n## Another Second";
+    let result = compile(source, "test.mdx").expect("compile should succeed");
+
+    let result: CompileResult = serde_wasm_bindgen::from_value(result).expect("deserialize result");
+
+    assert_eq!(result.headings.len(), 4);
+    assert_eq!(result.headings[0].depth, 1);
+    assert_eq!(result.headings[1].depth, 2);
+    assert_eq!(result.headings[2].depth, 3);
+    assert_eq!(result.headings[3].depth, 2);
+}
+
+#[wasm_bindgen_test]
+fn compile_filepath_in_output() {
+    let source = "# Test";
+    let result = compile(source, "/path/to/file.mdx").expect("compile should succeed");
+
+    let result: CompileResult = serde_wasm_bindgen::from_value(result).expect("deserialize result");
+
+    // Check filepath is included
+    assert!(result.code.contains("export const file ="));
+    assert!(result.code.contains("/path/to/file.mdx"));
+}


### PR DESCRIPTION
## Summary

Phase 3 の WASM バインディングアップグレード: NAPI と同等の `compile()` 関数を WASM に追加。

### Before / After

| Feature | NAPI | WASM (Before) | WASM (After) |
|---------|------|---------------|--------------|
| `compile()` → CompileResult | ✅ | ❌ | ✅ |
| `parse_blocks()` | ✅ | ✅ | ✅ |
| `render_html()` | ❌ | ✅ | ✅ |

### Changes

**New Types (`crates/wasm/src/lib.rs`)**
- `CompileResult` - コンパイル結果（code, frontmatter_json, headings, has_user_default_export）
- `HeadingEntry` - 見出しメタデータ（depth, slug, text）

**New Functions**
- `compile(source, filepath)` - MDX → Astro モジュール生成
- `blocks_to_jsx_string()` - RenderBlock → JSX 文字列変換
- `generate_module_code()` - Astro 互換モジュールコード生成

**New Tests (`crates/wasm/tests/compile.rs`)**
- `compile_basic_markdown` - 基本的な Markdown コンパイル
- `compile_with_frontmatter` - frontmatter 抽出
- `compile_with_imports` - import ホイスティング
- `compile_with_user_default_export` - ユーザー定義 export default
- `compile_multiple_headings` - 複数見出し抽出
- `compile_filepath_in_output` - ファイルパス出力

### Usage (JavaScript)

```javascript
import init, { compile } from './markflow_wasm.js';

await init();

const result = compile(`---
title: Hello
---

# Welcome

This is **bold** text.
`, 'page.mdx');

console.log(result.code);
// import { Fragment, jsx as __jsx } from 'astro/jsx-runtime';
// import { createComponent, renderJSX } from 'astro/runtime/server/index.js';
// export const frontmatter = {"title":"Hello"};
// export const file = "page.mdx";
// ...
// export default MarkflowContent;

console.log(result.headings);
// [{ depth: 1, slug: "welcome", text: "Welcome" }]

console.log(result.frontmatter_json);
// {"title":"Hello"}
```

## Test plan

- [x] `wasm-pack test --node crates/wasm` - 8 tests pass
- [x] `cargo build -p markflow-wasm` - ビルド成功
- [ ] ブラウザ環境での動作確認

## Future Work (Out of Scope)

- Layout support
- Source maps
- Full diagnostics