### PR TITLE
fix: escape backticks in text content to prevent template literal injection

### DIFF
--- a/crates/core/src/renderer/mdast.rs
+++ b/crates/core/src/renderer/mdast.rs
@@ -148,13 +148,15 @@ impl<'a> Context<'a> {
 
     /// Writes HTML-escaped text to the current HTML buffer (internal use).
     ///
-    /// Escapes `<`, `>`, and `&` characters for safe text node rendering.
+    /// Escapes `<`, `>`, `&`, and `` ` `` characters for safe text node rendering.
+    /// Backticks are escaped to prevent template literal injection in JSX contexts.
     fn push_escaped(&mut self, s: &str) {
         for c in s.chars() {
             match c {
                 '<' => self.current_html.push_str("&lt;"),
                 '>' => self.current_html.push_str("&gt;"),
                 '&' => self.current_html.push_str("&amp;"),
+                '`' => self.current_html.push_str("&#96;"),
                 _ => self.current_html.push(c),
             }
         }

--- a/crates/napi/tests/template_literal_bug.test.js
+++ b/crates/napi/tests/template_literal_bug.test.js
@@ -1,0 +1,69 @@
+import test from 'ava';
+import { createCompiler } from '../index.js';
+
+const compiler = createCompiler();
+
+test('inline code with template literal syntax should not be evaluated', async (t) => {
+  // This is the pattern that causes runtime errors:
+  // The ${variable} inside backticks should be treated as literal text
+  const source = 'Use `style={`--myVar:${value}`}` to set the style.';
+  const result = await compiler.compile(source, '/virtual.mdx');
+
+  // The output should NOT contain an actual template literal that would
+  // evaluate ${value} as a JavaScript expression
+  // It should contain escaped or quoted content
+  t.false(
+    result.code.includes('`--myVar:${value}`'),
+    'Template literal should not be present as raw backticks in output'
+  );
+
+  // The content should be safely rendered as a string
+  t.true(
+    result.code.includes('<code>'),
+    'Should contain code element'
+  );
+});
+
+test('inline code with dollar sign should be safe in JSX', async (t) => {
+  const source = 'Use `${variable}` in template literals.';
+  const result = await compiler.compile(source, '/virtual.mdx');
+
+  // Should not cause reference errors when evaluated
+  // The ${variable} should be escaped or rendered as text
+  t.true(
+    result.code.includes('<code>'),
+    'Should contain code element'
+  );
+});
+
+test('double backtick inline code preserves content', async (t) => {
+  // Double backticks are used to include backticks in inline code
+  const source = 'Use `` `template` `` for templates.';
+  const result = await compiler.compile(source, '/virtual.mdx');
+
+  t.true(
+    result.code.includes('<code>'),
+    'Should contain code element'
+  );
+});
+
+test('REPRO: double backtick with template literal causes runtime error', async (t) => {
+  // This is the exact pattern from astro-syntax.mdx that causes:
+  // "value is not defined" runtime error
+  const source = 'then you can manually add a ``style={`--myVar:${value}`}`` to your Element.';
+  const result = await compiler.compile(source, '/virtual.mdx');
+
+  console.log('Generated code:', result.code);
+
+  // The output should NOT contain an unescaped template literal
+  // that would cause ${value} to be evaluated
+  t.false(
+    /`[^`]*\$\{value\}[^`]*`/.test(result.code),
+    'Template literal should be escaped or quoted, not raw'
+  );
+
+  t.true(
+    result.code.includes('<code>'),
+    'Should contain code element'
+  );
+});


### PR DESCRIPTION
## Summary

When inline code contains backticks (e.g., `` `style={\`--myVar:${value}\`}` ``), the backticks were being preserved as-is in the JSX output, causing them to be interpreted as JavaScript template literals at runtime.

This caused "variable is not defined" errors when the template literal expressions like `${value}` were evaluated.

## The Fix

Escape backticks as HTML entities (`&#96;`) in the `push_escaped()` function in `crates/core/src/renderer/mdast.rs`.

**Before:**
```jsx
<code>style={`--myVar:${value}`}</code>
```

**After:**
```jsx
<code>style={&#96;--myVar:${value}&#96;}</code>
```

## Impact

This fix reduces the number of files that need to fall back to Astro MDX:
- `astro-syntax.mdx` and translations
- `directives-reference.mdx` and translations
- Other documentation files with template literal examples

## Test Plan

- [x] Added reproduction test in `crates/napi/tests/template_literal_bug.test.js`
- [x] All 4 template literal tests pass
- [x] No new test failures introduced

## Phase 5 Context

This is the first fix in the Phase 5: Optimization & Stabilization effort to reduce fallback rate from ~1500 files toward 0.