### PR TITLE
chore: remove trivial tests covered by withastro-docs

### DIFF
--- a/crates/core/tests/insta_tests.rs
+++ b/crates/core/tests/insta_tests.rs
@@ -11,16 +11,6 @@ fn snapshot_from(source: &str, input: &str) {
 }
 
 #[test]
-fn markdown_basic_snapshot() {
-    snapshot_from("markdown_basic", "# Hello, World!");
-}
-
-#[test]
-fn directive_note_snapshot() {
-    snapshot_from("directive_note", ":::note\nBody\n:::");
-}
-
-#[test]
 fn directive_inline_code_snapshot() {
     snapshot_from("directive_inline_code", "Here is `:::note` inside code");
 }

--- a/crates/core/tests/integration_tests.rs
+++ b/crates/core/tests/integration_tests.rs
@@ -13,21 +13,6 @@ fn read_fixture(path: &str) -> String {
 }
 
 #[test]
-fn test_parse() {
-    let input = "# Hello, World!";
-    let output = parse(input).unwrap().html;
-    assert!(output.contains("<h1 id=\"hello-world\">Hello, World!</h1>"));
-}
-
-#[test]
-fn test_parse_list() {
-    let input = "* Item 1\n* Item 2";
-    let output = parse(input).unwrap().html;
-    assert!(output.contains("<ul>"));
-    assert!(output.contains("<li>Item 1</li>"));
-}
-
-#[test]
 fn test_parse_applies_lazy_loading() {
     let input = "![alt](img.png)";
     let output = parse(input).unwrap().html;

--- a/crates/core/tests/snapshots/insta_tests__directive_note.snap
+++ b/crates/core/tests/snapshots/insta_tests__directive_note.snap
@@ -1,7 +1,0 @@
----
-source: directive_note
-expression: result
----
-<aside class="aside aside--note">
-Body
-</aside>

--- a/crates/core/tests/snapshots/insta_tests__markdown_basic.snap
+++ b/crates/core/tests/snapshots/insta_tests__markdown_basic.snap
@@ -1,5 +1,0 @@
----
-source: markdown_basic
-expression: result
----
-<h1 id="hello-world">Hello, World!</h1>


### PR DESCRIPTION
## Summary

Remove simple markdown parsing tests that are now redundant since withastro-docs (6000+ pages) serves as a comprehensive integration test (Golden Master).

## Deleted Tests

| File | Test | Reason |
|------|------|--------|
| `integration_tests.rs` | `test_parse()` | Basic heading parsing |
| `integration_tests.rs` | `test_parse_list()` | Basic list parsing |
| `insta_tests.rs` | `markdown_basic_snapshot()` | Simple `# Hello` test |
| `insta_tests.rs` | `directive_note_snapshot()` | Basic `:::note` test |

## Preserved Tests

- Component snapshots (10) - Feature flag verification
- MDX tests - Complex language features
- Edge case tests (slug deduplication, unicode, frontmatter errors, nested directives)

## Verification

- `cargo test` passes
- withastro-docs build succeeds (6000+ pages)