### PR TITLE
feat(napi): add parallel batch processing API with Rayon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "cssparser"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +170,12 @@ name = "dtor-proc-macro"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -434,6 +465,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+ "rayon",
  "serde",
  "serde_json",
 ]
@@ -658,6 +690,26 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "rustc-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,4 @@ wasm-bindgen-test = "0.3"
 js-sys = "0.3"
 insta = { version = "1.39.0", features = ["yaml"] }
 once_cell = "1.19"
+rayon = "1.10"

--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib"]
 markflow-core = { path = "../core" }
 napi = { workspace = true }
 napi-derive = { workspace = true }
+rayon = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/napi/src/batch.rs
+++ b/crates/napi/src/batch.rs
@@ -1,0 +1,64 @@
+//! Batch processing types and utilities for parallel compilation.
+
+use crate::types::{CompileIrResult, CompilerConfig};
+use napi_derive::napi;
+
+/// Input for batch processing - represents a single file to compile.
+#[napi(object)]
+#[derive(Debug, Clone)]
+pub struct BatchInput {
+    /// File identifier (typically the file path).
+    pub id: String,
+    /// Markdown/MDX source content.
+    pub source: String,
+    /// Optional filepath override for error messages and file type detection.
+    pub filepath: Option<String>,
+}
+
+/// Result for a single file in a batch.
+#[napi(object)]
+#[derive(Debug, Clone)]
+pub struct BatchResult {
+    /// File identifier matching the input.
+    pub id: String,
+    /// Compilation result (present on success).
+    pub result: Option<CompileIrResult>,
+    /// Error message (present on failure).
+    pub error: Option<String>,
+}
+
+/// Statistics for batch processing.
+#[napi(object)]
+#[derive(Debug, Clone)]
+pub struct BatchStats {
+    /// Total number of files processed.
+    pub total: u32,
+    /// Number of successfully compiled files.
+    pub succeeded: u32,
+    /// Number of failed compilations.
+    pub failed: u32,
+    /// Total processing time in milliseconds.
+    pub processing_time_ms: f64,
+}
+
+/// Options for batch processing.
+#[napi(object)]
+#[derive(Debug, Clone, Default)]
+pub struct BatchOptions {
+    /// Maximum number of threads to use. Defaults to number of CPU cores.
+    pub max_threads: Option<u32>,
+    /// Whether to continue processing after an error. Defaults to true.
+    pub continue_on_error: Option<bool>,
+    /// Compiler configuration to use for all files.
+    pub config: Option<CompilerConfig>,
+}
+
+/// Result of batch processing containing all results and statistics.
+#[napi(object)]
+#[derive(Debug, Clone)]
+pub struct BatchProcessingResult {
+    /// Individual results for each input file.
+    pub results: Vec<BatchResult>,
+    /// Processing statistics.
+    pub stats: BatchStats,
+}

--- a/crates/napi/src/compiler.rs
+++ b/crates/napi/src/compiler.rs
@@ -1,10 +1,14 @@
 //! The stateful compiler and its configuration.
 
+use crate::batch::*;
 use crate::types::*;
 use markflow_core::codegen::{DirectiveMappingResult, blocks_to_jsx_string};
 use markflow_core::{MarkflowError, MdastOptions, code_fence, to_blocks};
 use napi_derive::napi;
+use rayon::prelude::*;
 use std::path::Path;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Instant;
 
 const ASTRO_DEFAULT_RUNTIME: &str = "astro/runtime/server/index.js";
 
@@ -64,6 +68,109 @@ impl MarkflowCompiler {
         )?;
 
         compile_document_from_ir(ir)
+    }
+
+    /// Compiles multiple Markdown/MDX files in parallel using Rayon.
+    ///
+    /// This method uses the compiler's configuration for all files and processes
+    /// them concurrently for faster batch compilation.
+    ///
+    /// # Arguments
+    ///
+    /// * `inputs` - Array of files to compile
+    /// * `options` - Optional batch processing options (thread count, error handling)
+    ///
+    /// # Returns
+    ///
+    /// Returns a `BatchProcessingResult` containing individual results and statistics.
+    #[napi(js_name = "compileBatch")]
+    pub fn compile_batch(
+        &self,
+        inputs: Vec<BatchInput>,
+        options: Option<BatchOptions>,
+    ) -> napi::Result<BatchProcessingResult> {
+        let start = Instant::now();
+        let opts = options.unwrap_or_default();
+        let continue_on_error = opts.continue_on_error.unwrap_or(true);
+
+        // Use compiler's config, ignoring any config in batch options
+        let config = Some(CompilerConfig {
+            jsx_import_source: Some(self.config.jsx_import_source.clone()),
+            ..CompilerConfig::default()
+        });
+
+        // Configure thread pool if max_threads is specified
+        let pool = if let Some(max_threads) = opts.max_threads {
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(max_threads as usize)
+                .build()
+                .ok()
+        } else {
+            None
+        };
+
+        let total = inputs.len() as u32;
+        let succeeded = AtomicU32::new(0);
+        let failed = AtomicU32::new(0);
+
+        let process_input = |input: BatchInput| -> BatchResult {
+            let filepath = input.filepath.clone().unwrap_or_else(|| input.id.clone());
+            match compile_ir(input.source, filepath, None, config.clone()) {
+                Ok(result) => {
+                    succeeded.fetch_add(1, Ordering::Relaxed);
+                    BatchResult {
+                        id: input.id,
+                        result: Some(result),
+                        error: None,
+                    }
+                }
+                Err(e) => {
+                    failed.fetch_add(1, Ordering::Relaxed);
+                    BatchResult {
+                        id: input.id,
+                        result: None,
+                        error: Some(e.to_string()),
+                    }
+                }
+            }
+        };
+
+        let results: Vec<BatchResult> = if continue_on_error {
+            // Process all files regardless of errors
+            if let Some(pool) = pool {
+                pool.install(|| inputs.into_par_iter().map(process_input).collect())
+            } else {
+                inputs.into_par_iter().map(process_input).collect()
+            }
+        } else {
+            // Stop on first error - sequential processing required
+            let mut results = Vec::with_capacity(inputs.len());
+            let mut had_error = false;
+
+            for input in inputs {
+                if had_error {
+                    break;
+                }
+                let result = process_input(input);
+                if result.error.is_some() {
+                    had_error = true;
+                }
+                results.push(result);
+            }
+            results
+        };
+
+        let elapsed = start.elapsed();
+
+        Ok(BatchProcessingResult {
+            results,
+            stats: BatchStats {
+                total,
+                succeeded: succeeded.load(Ordering::Relaxed),
+                failed: failed.load(Ordering::Relaxed),
+                processing_time_ms: elapsed.as_secs_f64() * 1000.0,
+            },
+        })
     }
 }
 

--- a/crates/napi/src/lib.rs
+++ b/crates/napi/src/lib.rs
@@ -6,6 +6,8 @@ use napi::bindgen_prelude::*;
 use napi_derive::napi;
 use std::path::Path;
 
+/// Batch processing types and functions.
+pub mod batch;
 /// Module code generation helpers.
 mod codegen;
 /// The stateful compiler and its configuration.
@@ -17,6 +19,7 @@ pub mod types;
 /// Utility helpers.
 mod utils;
 #[allow(deprecated)]
+pub use batch::*;
 pub use types::*;
 use utils::empty_frontmatter;
 pub(crate) use utils::{build_import_list, dedupe_imports};
@@ -198,6 +201,136 @@ pub fn parse_blocks(input: String, opts: Option<BlockOptions>) -> napi::Result<P
         .collect();
 
     Ok(ParseBlocksResult { blocks, headings })
+}
+
+/// Compiles multiple Markdown/MDX files in parallel using Rayon.
+///
+/// This function processes files concurrently, leveraging all available CPU cores
+/// (or a specified maximum) for faster batch compilation.
+///
+/// # Arguments
+///
+/// * `inputs` - Array of files to compile, each with an id, source, and optional filepath
+/// * `options` - Optional batch processing options (thread count, error handling, config)
+///
+/// # Returns
+///
+/// Returns a `BatchProcessingResult` containing individual results and statistics.
+///
+/// # Example (JavaScript)
+///
+/// ```javascript
+/// const { compileBatch } = require('markflow-napi');
+///
+/// const inputs = [
+///   { id: 'file1.mdx', source: '# Hello\nWorld' },
+///   { id: 'file2.mdx', source: '# Goodbye\nWorld' },
+/// ];
+///
+/// const result = compileBatch(inputs, { continueOnError: true });
+/// console.log(`Processed ${result.stats.total} files in ${result.stats.processingTimeMs}ms`);
+/// ```
+#[napi(js_name = "compileBatch")]
+pub fn compile_batch(
+    inputs: Vec<BatchInput>,
+    options: Option<BatchOptions>,
+) -> napi::Result<BatchProcessingResult> {
+    use rayon::prelude::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::time::Instant;
+
+    let start = Instant::now();
+    let opts = options.unwrap_or_default();
+    let continue_on_error = opts.continue_on_error.unwrap_or(true);
+    let config = opts.config.clone();
+
+    // Configure thread pool if max_threads is specified
+    let pool = if let Some(max_threads) = opts.max_threads {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(max_threads as usize)
+            .build()
+            .ok()
+    } else {
+        None
+    };
+
+    let total = inputs.len() as u32;
+    let succeeded = AtomicU32::new(0);
+    let failed = AtomicU32::new(0);
+
+    let process_input = |input: BatchInput| -> BatchResult {
+        let filepath = input.filepath.clone().unwrap_or_else(|| input.id.clone());
+        match compiler::compile_ir(input.source, filepath, None, config.clone()) {
+            Ok(result) => {
+                succeeded.fetch_add(1, Ordering::Relaxed);
+                BatchResult {
+                    id: input.id,
+                    result: Some(result),
+                    error: None,
+                }
+            }
+            Err(e) => {
+                failed.fetch_add(1, Ordering::Relaxed);
+                BatchResult {
+                    id: input.id,
+                    result: None,
+                    error: Some(e.to_string()),
+                }
+            }
+        }
+    };
+
+    let results: Vec<BatchResult> = if continue_on_error {
+        // Process all files regardless of errors
+        if let Some(pool) = pool {
+            pool.install(|| inputs.into_par_iter().map(process_input).collect())
+        } else {
+            inputs.into_par_iter().map(process_input).collect()
+        }
+    } else {
+        // Stop on first error - use try_for_each pattern
+        let mut results = Vec::with_capacity(inputs.len());
+        let mut had_error = false;
+
+        if let Some(pool) = pool {
+            pool.install(|| {
+                for input in inputs {
+                    if had_error {
+                        break;
+                    }
+                    let result = process_input(input);
+                    if result.error.is_some() {
+                        had_error = true;
+                    }
+                    results.push(result);
+                }
+            });
+        } else {
+            for input in inputs {
+                if had_error {
+                    break;
+                }
+                let result = process_input(input);
+                if result.error.is_some() {
+                    had_error = true;
+                }
+                results.push(result);
+            }
+        }
+        results
+    };
+
+    let elapsed = start.elapsed();
+
+    Ok(BatchProcessingResult {
+        results,
+        stats: BatchStats {
+            total,
+            succeeded: succeeded.load(Ordering::Relaxed),
+            failed: failed.load(Ordering::Relaxed),
+            processing_time_ms: elapsed.as_secs_f64() * 1000.0,
+        },
+    })
 }
 
 /// Represents the type of the input file, either Markdown or MDX.


### PR DESCRIPTION
## Summary
- Add `compileBatch` standalone function and `MarkflowCompiler.compileBatch` method for processing multiple Markdown/MDX files in parallel using Rayon
- Add batch processing types: `BatchInput`, `BatchResult`, `BatchStats`, `BatchOptions`, `BatchProcessingResult`
- Support configurable thread pool size via `maxThreads` option
- Support `continueOnError` option to control error handling behavior

## API

### Standalone function
```typescript
function compileBatch(inputs: BatchInput[], options?: BatchOptions): BatchProcessingResult;
```

### MarkflowCompiler method
```typescript
class MarkflowCompiler {
  compileBatch(inputs: BatchInput[], options?: BatchOptions): BatchProcessingResult;
}
```

### Types
```typescript
interface BatchInput {
  id: string;
  source: string;
  filepath?: string;
}

interface BatchOptions {
  maxThreads?: number;
  continueOnError?: boolean;
  config?: CompilerConfig;
}

interface BatchProcessingResult {
  results: BatchResult[];
  stats: BatchStats;
}

interface BatchResult {
  id: string;
  result?: CompileIrResult;
  error?: string;
}

interface BatchStats {
  total: number;
  succeeded: number;
  failed: number;
  processingTimeMs: number;
}
```

## Test plan
- [x] Build with `cargo build -p markflow-napi`
- [x] Run tests with `cargo test -p markflow-napi`
- [x] Verify NAPI bindings with `npm run build`
- [x] Verify TypeScript types are generated correctly in `index.d.ts`