### PR TITLE
fix(plugin): remove overly aggressive pre-validation

### DIFF
--- a/packages/vite-plugin-markflow/src/index.js
+++ b/packages/vite-plugin-markflow/src/index.js
@@ -138,8 +138,6 @@ export function markflowPlugin(userOptions = {}) {
   const sourceLookup = new Map();
   const fallbackFiles = new Set();
   const fallbackReasons = new Map(); // file -> reason
-  const preValidationSkips = new Set(); // files skipped during pre-validation in resolveId
-  const preValidationReasons = new Map(); // file -> reason for pre-validation skip
   const processedFiles = new Set();
   let totalProcessingTimeMs = 0;
 
@@ -242,30 +240,6 @@ const unwrapVirtual = (value) =>
         return null;
       }
 
-      // Check if file was already skipped during pre-validation
-      if (preValidationSkips.has(resolvedId)) {
-        return null;
-      }
-
-      // Pre-validation: detect problematic patterns before creating virtual module
-      // This prevents the timing issue where resolveId creates a virtual module
-      // but load() then discovers an error and falls back incorrectly
-      try {
-        const source = await readFile(resolvedId, "utf8");
-        const preValidationError = preValidateSource(source);
-        if (preValidationError) {
-          preValidationSkips.add(resolvedId);
-          preValidationReasons.set(resolvedId, preValidationError);
-          console.warn(
-            `[markflow] Skipping ${resolvedId}: ${preValidationError} (letting Astro MDX handle it)`,
-          );
-          return null; // Let Astro handle this file from the start
-        }
-      } catch {
-        // If we can't read the file, let Vite handle the error normally
-        // Don't block resolution for missing files
-      }
-
       const virtualId = `${VIRTUAL_PREFIX}${resolvedId}.markflow.jsx`;
       sourceLookup.set(virtualId, resolvedId);
       return virtualId;
@@ -282,13 +256,6 @@ const unwrapVirtual = (value) =>
         stripQuery(id.slice(VIRTUAL_PREFIX.length).replace(/\.markflow\.jsx$/, ""));
       try {
         const source = await readFile(filename, "utf8");
-
-        // Check for problematic patterns that cause runtime errors in Starlight components
-        const validationError = validateStarlightComponents(source);
-        if (validationError) {
-          throw new Error(`Markdown parser error: ${validationError}`);
-        }
-
         const fileOptions = deriveFileOptions(filename, resolvedConfig?.root);
 
         const startTime = performance.now();
@@ -400,25 +367,21 @@ const unwrapVirtual = (value) =>
     async buildEnd() {
       if (process.env.MARKFLOW_STATS !== "1") return;
 
-      const totalHandledByAstro = preValidationSkips.size + fallbackFiles.size;
-      const totalFiles = processedFiles.size + totalHandledByAstro;
+      const totalFiles = processedFiles.size + fallbackFiles.size;
 
       const stats = {
         timestamp: new Date().toISOString(),
         totalFiles,
         processedByMarkflow: processedFiles.size,
-        handledByAstro: totalHandledByAstro,
+        handledByAstro: fallbackFiles.size,
         handledByAstroRate:
           totalFiles > 0
-            ? `${((totalHandledByAstro / totalFiles) * 100).toFixed(2)}%`
+            ? `${((fallbackFiles.size / totalFiles) * 100).toFixed(2)}%`
             : "0%",
-        // Pre-validation skips: detected in resolveId before creating virtual module
+        // Pre-validation skips removed - was causing false positives
         preValidationSkips: {
-          count: preValidationSkips.size,
-          files: Array.from(preValidationSkips).map((file) => ({
-            file: file.replace(resolvedConfig?.root ?? "", ""),
-            reason: preValidationReasons.get(file) ?? "unknown",
-          })),
+          count: 0,
+          files: [],
         },
         // Runtime fallbacks: errors discovered during compilation in load()
         runtimeFallbacks: {
@@ -431,8 +394,8 @@ const unwrapVirtual = (value) =>
         // Legacy fields for backwards compatibility
         fallbacks: fallbackFiles.size,
         fallbackRate:
-          processedFiles.size + fallbackFiles.size > 0
-            ? `${((fallbackFiles.size / (processedFiles.size + fallbackFiles.size)) * 100).toFixed(2)}%`
+          totalFiles > 0
+            ? `${((fallbackFiles.size / totalFiles) * 100).toFixed(2)}%`
             : "0%",
         fallbackFiles: Array.from(fallbackFiles).map((file) => ({
           file: file.replace(resolvedConfig?.root ?? "", ""),
@@ -824,54 +787,4 @@ function getText(node) {
     }
   }
   return text;
-}
-
-/**
- * Validate that Starlight components don't contain problematic patterns.
- * Returns an error message if a problem is found, null otherwise.
- * @param {string} source - The markdown source
- * @returns {string|null} Error message or null
- */
-function validateStarlightComponents(source) {
-  // Check for problematic patterns inside Steps blocks
-  // Note: With code_indented: false in the Rust parser, nested content inside Steps
-  // (JSX components, code fences, continuation paragraphs) is now handled correctly.
-  // Deep indentation is interpreted as nested list content instead of code blocks.
-
-  return null;
-}
-
-/**
- * Performs lightweight pre-validation of source to detect patterns known to cause
- * compilation failures. This runs in resolveId() BEFORE creating virtual modules,
- * allowing problematic files to fall back to Astro MDX from the start.
- *
- * @param {string} source - The markdown/mdx source content
- * @returns {string|null} Error reason if pre-validation fails, null if OK
- */
-function preValidateSource(source) {
-  // 1. Template literals in inline code blocks cause JSX parsing issues
-  // Match: `something ${expr} else` (inline code containing template literal syntax)
-  if (/`[^`\n]*\$\{[^`\n]*\}[^`\n]*`/.test(source)) {
-    return "Contains template literals in inline code";
-  }
-
-  // 2. Custom component imports from ~/components/ are not yet supported
-  // These need special handling that Markflow doesn't provide
-  if (/import\s+\w+\s+from\s+['"]~\/components\//.test(source)) {
-    return "Contains custom component imports from ~/components/";
-  }
-
-  // 3. Dynamic import expressions in MDX can cause issues
-  if (/import\s*\([^)]*\)/.test(source)) {
-    return "Contains dynamic import expressions";
-  }
-
-  // 4. Complex JSX expressions with nested template literals
-  // Match JSX attributes with template literal values: prop={`...${...}...`}
-  if (/\{`[^`]*\$\{[^}]+\}[^`]*`\}/.test(source)) {
-    return "Contains JSX with nested template literal expressions";
-  }
-
-  return null; // No issues detected
 }


### PR DESCRIPTION
## Summary

- Removes pre-validation that was causing false positives and skipping files that would compile correctly
- Template literals in script/JSX blocks, valid MDX imports, and dynamic imports were incorrectly flagged
- The runtime fallback in load() already handles genuine compilation errors

## Changes

- Removed preValidateSource() function and all validation patterns
- Removed validateStarlightComponents() function  
- Removed preValidationSkips/preValidationReasons tracking
- Stats output retains preValidationSkips with count: 0 for backwards compatibility

## Test plan

- [x] All 189 unit tests pass
- [ ] Run docs build to verify no more false positive skip messages
- [ ] Verify increased Markflow coverage (fewer unnecessary fallbacks)