### PR TITLE
fix(plugin): reduce fallback rate by wrapping batch HTML in JSX module

### DIFF
--- a/packages/vite-plugin-markflow/src/index.js
+++ b/packages/vite-plugin-markflow/src/index.js
@@ -348,9 +348,6 @@ const unwrapVirtual = (value) =>
         const isMdx = filename.endsWith('.mdx');
         const hasUserImports = cached?.hoistedImports?.length > 0;
         const hasJsxComponents = cached?.html && /\{\.\.\.|\<[A-Z]/.test(cached.html);
-        if (cached) {
-          console.log(`[markflow] Cache check for ${filename}: isMdx=${isMdx}, hasUserImports=${hasUserImports} (${cached?.hoistedImports?.length}), hasJsxComponents=${hasJsxComponents}`);
-        }
         if (cached && !hasUserImports && !hasJsxComponents && !isMdx) {
           // compileBatch returns CompileIrResult with 'html' field (raw HTML)
           // We need to wrap it in a JSX module structure


### PR DESCRIPTION
## Summary
- Adds `buildStart` hook for batch compilation in build mode
- Wraps raw HTML from batch results in proper JSX module structure  
- Reduces fallback rate from ~51% to ~4% on withastro/docs

## Root Cause
The batch compilation returns raw HTML in the `html` field, but the plugin code expected a complete JSX module. This caused esbuild transform errors like "Expected ';' but found 'id'" because raw HTML attributes aren't valid JSX.

## Changes
- Added `compilationCache` to store batch compilation results
- Added `buildStart` hook to batch compile all MD/MDX files in build mode
- Added `wrapHtmlInJsxModule()` to wrap raw HTML in a JSX module with `<Fragment set:html={...} />`
- Updated `load` function to check cache first

## Results
| Metric | Before | After |
|--------|--------|-------|
| Fallback rate | 50.87% | 3.71% |
| Files processed by Markflow | 2309 | 2309 |
| Fallbacks to Astro MDX | 2391 | 89 |

Remaining 89 fallbacks are parser errors (end-tag-mismatch issues in nested JSX components).