### PR TITLE
feat(plugin): make Shiki + mdast pipeline the default

### DIFF
--- a/packages/vite-plugin-markflow/src/index.js
+++ b/packages/vite-plugin-markflow/src/index.js
@@ -2,7 +2,6 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { transformWithEsbuild } from "vite";
 import { parseFragment, serialize } from "parse5";
-import { codeToHtml, createCssVariablesTheme } from "shiki";
 import { createRegistry, starlightLibrary, astroLibrary, expressiveCodeLibrary } from "markflow/registry";
 import { pipe, when } from "./pipeline/pipe.js";
 import {
@@ -12,6 +11,7 @@ import {
 } from "./transforms/index.js";
 import { blocksToJsx } from "./transforms/blocks-to-jsx.js";
 import { resolveExpressiveCodeConfig } from "./utils/config.js";
+import { ShikiWorkerPool, createPooledHighlighter } from "./workers/shiki-pool.js";
 
 const DEFAULT_EXTENSIONS = new Set([".md", ".mdx"]);
 
@@ -46,8 +46,6 @@ export function resolveLibraries(options) {
 let bindingPromise;
 const VIRTUAL_PREFIX = "\0markflow:";
 const DEBUG_BINDING = process.env.MARKFLOW_DEBUG_BINDING === "1";
-const ENABLE_SHIKI = process.env.MARKFLOW_SHIKI === "1";
-const IS_MDAST = process.env.MARKFLOW_PIPELINE === "mdast";
 
 const logBindingSource = (source) => {
   if (!DEBUG_BINDING) return;
@@ -227,15 +225,12 @@ export function markflowPlugin(userOptions = {}) {
       ? value.slice(VIRTUAL_PREFIX.length)
       : value;
 
-  let shikiReady;
+  /** @type {ShikiWorkerPool | null} */
+  let shikiPool = null;
+  /** @type {((code: string, lang: string) => Promise<string>) | null} */
+  let shikiHighlighter = null;
 
-  const getShiki = () => {
-    if (!ENABLE_SHIKI || !IS_MDAST) return null;
-    if (!shikiReady) {
-      shikiReady = createShikiHighlighter();
-    }
-    return shikiReady;
-  };
+  const getShiki = () => shikiHighlighter;
 
   return {
     name: "vite-plugin-markflow",
@@ -265,6 +260,14 @@ export function markflowPlugin(userOptions = {}) {
       compiler = createCompiler(compilerOptions);
     },
     async buildStart() {
+      // Initialize Shiki worker pool
+      shikiPool = new ShikiWorkerPool();
+      await shikiPool.ready();
+      shikiHighlighter = createPooledHighlighter(shikiPool);
+      if (process.env.MARKFLOW_STATS === '1') {
+        console.info(`[markflow] Shiki worker pool initialized with ${shikiPool.size} workers`);
+      }
+
       // Only batch compile in build mode (not dev/serve)
       if (resolvedConfig.command !== 'build') return;
 
@@ -404,7 +407,7 @@ export function markflowPlugin(userOptions = {}) {
             headings,
             imports: [],
           };
-        } else if (IS_MDAST) {
+        } else {
           // Use parseBlocks() for mdast pipeline
           const binding = await loadMarkflowBinding();
           const parseResult = binding.parseBlocks(source, {
@@ -421,19 +424,6 @@ export function markflowPlugin(userOptions = {}) {
             headings,
             imports: [],
           };
-        } else {
-          // Use original compiler for multipass pipeline (dev mode or cache miss)
-          const fileOptions = deriveFileOptions(filename, resolvedConfig?.root);
-          result = compiler.compile(source, filename, fileOptions);
-          // Extract frontmatter and headings from compiler result
-          if (result.frontmatter_json) {
-            try {
-              frontmatter = JSON.parse(result.frontmatter_json);
-            } catch {
-              frontmatter = {};
-            }
-          }
-          headings = result.headings || [];
         }
         const endTime = performance.now();
         totalProcessingTimeMs += endTime - startTime;
@@ -547,6 +537,13 @@ export function markflowPlugin(userOptions = {}) {
       }
     },
     async buildEnd() {
+      // Terminate Shiki worker pool
+      if (shikiPool) {
+        await shikiPool.terminate();
+        shikiPool = null;
+        shikiHighlighter = null;
+      }
+
       if (process.env.MARKFLOW_STATS !== "1") return;
 
       const totalFiles = processedFiles.size + fallbackFiles.size;
@@ -651,33 +648,6 @@ function createFallbackModule(filename) {
   };
 }
 
-function createShikiHighlighter() {
-  const theme = createCssVariablesTheme({
-    name: "astro-code",
-    variablePrefix: "--astro-code-",
-  });
-  const cache = new Map();
-  return async (code, lang) => {
-    const key = `${lang || "text"}`;
-    let cached = cache.get(key);
-    if (!cached) {
-      cached = { lang: lang || "text" };
-      cache.set(key, cached);
-    }
-    const html = await codeToHtml(code, {
-      lang: cached.lang,
-      theme,
-    });
-    return html.replace(/<pre class="([^"]*)"/, (match, classes) => {
-      const normalized = classes
-        .split(/\s+/)
-        .filter((value) => value && value !== "shiki")
-        .join(" ");
-      const next = normalized ? `astro-code ${normalized}` : "astro-code";
-      return `<pre class="${next}"`;
-    });
-  };
-}
 
 async function rewriteAstroSetHtml(code, highlight) {
   const marker = "<Fragment set:html={";

--- a/packages/vite-plugin-markflow/src/workers/shiki-pool.js
+++ b/packages/vite-plugin-markflow/src/workers/shiki-pool.js
@@ -1,0 +1,258 @@
+/**
+ * Shiki Worker Pool
+ *
+ * Manages a pool of worker threads for parallel Shiki syntax highlighting.
+ * Uses worker_threads to bypass Node.js single-threaded limitations for CPU-bound tasks.
+ */
+import { Worker } from 'node:worker_threads';
+import { cpus } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const WORKER_PATH = path.join(__dirname, 'shiki-worker.js');
+
+/**
+ * @typedef {Object} PendingTask
+ * @property {string} id - Unique task identifier
+ * @property {string} code - Code to highlight
+ * @property {string} lang - Language for highlighting
+ * @property {function} resolve - Promise resolve callback
+ * @property {function} reject - Promise reject callback
+ */
+
+/**
+ * @typedef {Object} WorkerState
+ * @property {Worker} worker - The worker thread instance
+ * @property {boolean} busy - Whether the worker is currently processing
+ * @property {boolean} ready - Whether the worker has signaled ready
+ * @property {Map<string, PendingTask>} pending - Pending tasks for this worker
+ */
+
+export class ShikiWorkerPool {
+  /** @type {WorkerState[]} */
+  #workers = [];
+
+  /** @type {PendingTask[]} */
+  #queue = [];
+
+  /** @type {number} */
+  #nextTaskId = 0;
+
+  /** @type {boolean} */
+  #terminated = false;
+
+  /** @type {Promise<void>} */
+  #readyPromise;
+
+  /**
+   * Creates a new Shiki worker pool.
+   * @param {number} [size] - Number of workers (defaults to CPU count)
+   */
+  constructor(size = Math.max(1, cpus().length - 1)) {
+    const readyPromises = [];
+
+    for (let i = 0; i < size; i++) {
+      const worker = new Worker(WORKER_PATH);
+      const state = {
+        worker,
+        busy: false,
+        ready: false,
+        pending: new Map(),
+      };
+
+      // Track ready promise
+      const readyPromise = new Promise((resolve) => {
+        const readyHandler = (msg) => {
+          if (msg.type === 'ready') {
+            state.ready = true;
+            worker.off('message', readyHandler);
+            resolve();
+          }
+        };
+        worker.on('message', readyHandler);
+      });
+      readyPromises.push(readyPromise);
+
+      // Handle responses
+      worker.on('message', (msg) => {
+        if (msg.type === 'ready') return;
+
+        const { id, html, error } = msg;
+        const task = state.pending.get(id);
+        if (!task) return;
+
+        state.pending.delete(id);
+        state.busy = state.pending.size > 0;
+
+        if (error) {
+          task.reject(new Error(error));
+        } else {
+          task.resolve(html);
+        }
+
+        // Process next task in queue
+        this.#processQueue();
+      });
+
+      worker.on('error', (error) => {
+        // Reject all pending tasks for this worker
+        for (const [, task] of state.pending) {
+          task.reject(error);
+        }
+        state.pending.clear();
+        state.busy = false;
+        this.#processQueue();
+      });
+
+      this.#workers.push(state);
+    }
+
+    // Wait for all workers to be ready
+    this.#readyPromise = Promise.all(readyPromises).then(() => {});
+  }
+
+  /**
+   * Waits for the pool to be ready.
+   * @returns {Promise<void>}
+   */
+  async ready() {
+    return this.#readyPromise;
+  }
+
+  /**
+   * Get pool size (number of workers).
+   * @returns {number}
+   */
+  get size() {
+    return this.#workers.length;
+  }
+
+  /**
+   * Highlights code using an available worker.
+   * @param {string} code - Code to highlight
+   * @param {string} [lang] - Language for highlighting
+   * @returns {Promise<string>} Highlighted HTML
+   */
+  async highlight(code, lang) {
+    if (this.#terminated) {
+      throw new Error('Worker pool has been terminated');
+    }
+
+    // Wait for workers to be ready
+    await this.#readyPromise;
+
+    const id = `task-${this.#nextTaskId++}`;
+
+    return new Promise((resolve, reject) => {
+      const task = { id, code, lang, resolve, reject };
+
+      // Find an available worker
+      const availableWorker = this.#workers.find((w) => !w.busy && w.ready);
+
+      if (availableWorker) {
+        this.#dispatchTask(availableWorker, task);
+      } else {
+        // Queue the task
+        this.#queue.push(task);
+      }
+    });
+  }
+
+  /**
+   * Dispatches a task to a worker.
+   * @param {WorkerState} workerState
+   * @param {PendingTask} task
+   */
+  #dispatchTask(workerState, task) {
+    workerState.busy = true;
+    workerState.pending.set(task.id, task);
+    workerState.worker.postMessage({
+      id: task.id,
+      code: task.code,
+      lang: task.lang,
+    });
+  }
+
+  /**
+   * Processes queued tasks.
+   */
+  #processQueue() {
+    if (this.#queue.length === 0) return;
+
+    const availableWorker = this.#workers.find((w) => !w.busy && w.ready);
+    if (!availableWorker) return;
+
+    const task = this.#queue.shift();
+    if (task) {
+      this.#dispatchTask(availableWorker, task);
+    }
+  }
+
+  /**
+   * Terminates all workers in the pool.
+   * @returns {Promise<void>}
+   */
+  async terminate() {
+    if (this.#terminated) return;
+    this.#terminated = true;
+
+    // Reject all queued tasks
+    for (const task of this.#queue) {
+      task.reject(new Error('Worker pool terminated'));
+    }
+    this.#queue = [];
+
+    // Terminate all workers
+    await Promise.all(
+      this.#workers.map(async (state) => {
+        // Reject pending tasks
+        for (const [, task] of state.pending) {
+          task.reject(new Error('Worker pool terminated'));
+        }
+        state.pending.clear();
+        await state.worker.terminate();
+      })
+    );
+
+    this.#workers = [];
+  }
+}
+
+// Singleton instance for the plugin
+let poolInstance = null;
+
+/**
+ * Creates or returns the singleton pool instance.
+ * @param {number} [size] - Pool size (only used on first call)
+ * @returns {ShikiWorkerPool}
+ */
+export function getShikiPool(size) {
+  if (!poolInstance) {
+    poolInstance = new ShikiWorkerPool(size);
+  }
+  return poolInstance;
+}
+
+/**
+ * Terminates the singleton pool instance.
+ * @returns {Promise<void>}
+ */
+export async function terminateShikiPool() {
+  if (poolInstance) {
+    await poolInstance.terminate();
+    poolInstance = null;
+  }
+}
+
+/**
+ * Creates a highlighter function that uses the worker pool.
+ * @param {ShikiWorkerPool} pool
+ * @returns {(code: string, lang: string) => Promise<string>}
+ */
+export function createPooledHighlighter(pool) {
+  return async (code, lang) => {
+    return pool.highlight(code, lang);
+  };
+}

--- a/packages/vite-plugin-markflow/src/workers/shiki-pool.test.js
+++ b/packages/vite-plugin-markflow/src/workers/shiki-pool.test.js
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import { ShikiWorkerPool, createPooledHighlighter } from './shiki-pool.js';
+
+describe('ShikiWorkerPool', () => {
+  let pool;
+
+  beforeAll(async () => {
+    pool = new ShikiWorkerPool(2); // Use 2 workers for testing
+    await pool.ready();
+  });
+
+  afterAll(async () => {
+    if (pool) {
+      await pool.terminate();
+    }
+  });
+
+  it('initializes with the correct number of workers', () => {
+    expect(pool.size).toBe(2);
+  });
+
+  it('highlights simple code', async () => {
+    const html = await pool.highlight('const x = 1;', 'javascript');
+
+    expect(html).toContain('<pre class="astro-code');
+    expect(html).toContain('const');
+    expect(html).toContain('x');
+  });
+
+  it('highlights code without language', async () => {
+    const html = await pool.highlight('hello world', null);
+
+    expect(html).toContain('<pre class="astro-code');
+    expect(html).toContain('hello');
+  });
+
+  it('processes multiple highlights in parallel', async () => {
+    const codes = [
+      { code: 'const a = 1;', lang: 'javascript' },
+      { code: 'def foo(): pass', lang: 'python' },
+      { code: '<div>hello</div>', lang: 'html' },
+      { code: 'SELECT * FROM users', lang: 'sql' },
+    ];
+
+    const results = await Promise.all(
+      codes.map(({ code, lang }) => pool.highlight(code, lang))
+    );
+
+    expect(results).toHaveLength(4);
+    results.forEach((html) => {
+      expect(html).toContain('<pre class="astro-code');
+    });
+  });
+
+  it('handles many concurrent requests with queue', async () => {
+    const count = 10;
+    const promises = [];
+
+    for (let i = 0; i < count; i++) {
+      promises.push(pool.highlight(`const x${i} = ${i};`, 'javascript'));
+    }
+
+    const results = await Promise.all(promises);
+
+    expect(results).toHaveLength(count);
+    results.forEach((html, i) => {
+      expect(html).toContain('<pre class="astro-code');
+      expect(html).toContain(`x${i}`);
+    });
+  });
+});
+
+describe('createPooledHighlighter', () => {
+  let pool;
+  let highlighter;
+
+  beforeAll(async () => {
+    pool = new ShikiWorkerPool(1);
+    await pool.ready();
+    highlighter = createPooledHighlighter(pool);
+  });
+
+  afterAll(async () => {
+    if (pool) {
+      await pool.terminate();
+    }
+  });
+
+  it('returns a function that highlights code', async () => {
+    const html = await highlighter('const x = 1;', 'javascript');
+
+    expect(html).toContain('<pre class="astro-code');
+    expect(html).toContain('const');
+  });
+});
+
+describe('ShikiWorkerPool termination', () => {
+  it('throws error after termination', async () => {
+    const tempPool = new ShikiWorkerPool(1);
+    await tempPool.ready();
+    await tempPool.terminate();
+
+    await expect(tempPool.highlight('code', 'javascript')).rejects.toThrow(
+      'Worker pool has been terminated'
+    );
+  });
+
+  it('can be terminated multiple times safely', async () => {
+    const tempPool = new ShikiWorkerPool(1);
+    await tempPool.ready();
+    await tempPool.terminate();
+    await tempPool.terminate(); // Should not throw
+  });
+});

--- a/packages/vite-plugin-markflow/src/workers/shiki-worker.js
+++ b/packages/vite-plugin-markflow/src/workers/shiki-worker.js
@@ -1,0 +1,41 @@
+/**
+ * Shiki Worker Thread
+ *
+ * This worker handles Shiki syntax highlighting in a separate thread,
+ * enabling true parallel CPU-bound processing across multiple cores.
+ */
+import { parentPort, workerData } from 'node:worker_threads';
+import { codeToHtml, createCssVariablesTheme } from 'shiki';
+
+// Create the theme once per worker
+const theme = createCssVariablesTheme({
+  name: 'astro-code',
+  variablePrefix: '--astro-code-',
+});
+
+// Process highlight requests
+parentPort.on('message', async ({ id, code, lang }) => {
+  try {
+    const html = await codeToHtml(code, {
+      lang: lang || 'text',
+      theme,
+    });
+
+    // Normalize CSS classes to match Astro's expected format
+    const normalized = html.replace(/<pre class="([^"]*)"/, (match, classes) => {
+      const filtered = classes
+        .split(/\s+/)
+        .filter((value) => value && value !== 'shiki')
+        .join(' ');
+      const next = filtered ? `astro-code ${filtered}` : 'astro-code';
+      return `<pre class="${next}"`;
+    });
+
+    parentPort.postMessage({ id, html: normalized, error: null });
+  } catch (error) {
+    parentPort.postMessage({ id, html: null, error: error.message });
+  }
+});
+
+// Signal ready
+parentPort.postMessage({ type: 'ready' });


### PR DESCRIPTION
## Summary

- Remove `MARKFLOW_SHIKI` and `MARKFLOW_PIPELINE` feature flags
- Shiki syntax highlighting with worker pool is now always enabled
- mdast pipeline (`parseBlocks()`) is now the default and only pipeline

## Changes

- Remove `ENABLE_SHIKI` and `IS_MDAST` constants from `src/index.js`
- Initialize `ShikiWorkerPool` unconditionally in `buildStart`
- Simplify `getShiki()` to always return the highlighter
- Remove legacy multipass pipeline branch from `load()`
- Add worker pool cleanup in `buildEnd`
- Add `workers/` directory with Shiki worker pool implementation

## Test plan

- [x] Run `bun test packages/vite-plugin-markflow` - all tests pass
- [ ] Build a project without feature flags and verify Shiki highlighting works

🤖 Generated with [Claude Code](https://claude.com/claude-code)