### PR TITLE
perf(plugin): disable preventive pattern detection to reduce fallback rate

### DIFF
--- a/packages/astro-markflow/src/vite-plugin.js
+++ b/packages/astro-markflow/src/vite-plugin.js
@@ -610,18 +610,22 @@ export default function MarkflowContent() {
  * These files should fall back to Astro MDX immediately.
  */
 function hasProblematicMdxPatterns(source) {
-  // Pattern 1: Code fences inside JSX blocks (TabItem, Fragment with slot)
-  // The ``` inside JSX confuses the parser
-  const hasCodeFenceInJsx = /<(TabItem|Fragment[^>]*slot=)[^>]*>[\s\S]*?```[\s\S]*?<\//.test(source);
-
-  // Pattern 2: Nested interactive components (MultipleChoice > Box)
-  // markdown-rs struggles with nested JSX containing markdown
-  const hasNestedInteractive = /<MultipleChoice[\s\S]*?<Box/.test(source);
-
-  // Pattern 3: Steps/FileTree with complex nesting
-  const hasComplexSteps = /<Steps[\s\S]*?<details[\s\S]*?<\/Steps>/.test(source);
-
-  return hasCodeFenceInJsx || hasNestedInteractive || hasComplexSteps;
+  // Investigation results (2026-01-18):
+  // - Before: 733 files skipped (30%) due to preventive pattern detection
+  // - After disabling: Only 118 files (4.85%) actually fail at runtime
+  // - Improvement: 615 files (84%) were being unnecessarily skipped
+  //
+  // The runtime fallback mechanism works correctly and is fast enough.
+  // Preventive pattern detection is no longer needed.
+  //
+  // True failures fall into two categories:
+  // 1. Transform errors (~36 files): JSX generation bugs (separate issue)
+  // 2. Markdown parser errors (~82 files): Genuine markdown-rs limitations
+  //    - <MultipleChoice>...<Box> with markdown content
+  //    - <Steps>...<details> nesting
+  //    - <TabItem> with code fences
+  //    - <Fragment> inside list items
+  return false;
 }
 
 function createFallbackModule(filename) {


### PR DESCRIPTION
## Summary

- Disable preventive MDX pattern detection that was causing excessive fallbacks
- Reduce fallback rate from 30% to 4.85% on withastro-docs benchmark
- Document investigation findings in code comments

## Investigation Results

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Total files | 2,422 | 2,432 | - |
| Markflow processed | 1,689 (70%) | 2,314 (95.15%) | +625 files |
| Astro fallback | 733 (30%) | 118 (4.85%) | -615 files |

**Finding:** 84% of previously skipped files can actually be processed successfully. The runtime fallback mechanism is fast and reliable, making preventive pattern detection unnecessary.

### True Failures (118 files)

1. **Transform errors (~36 files):** JSX generation bugs (separate issue)
   - `guides/astro-db.mdx`, `reference/modules/astro-*.mdx`, etc.

2. **Markdown parser errors (~82 files):** Genuine markdown-rs limitations
   - `<MultipleChoice>...<Box>` with markdown content
   - `<Steps>...<details>` nesting  
   - `<TabItem>` with code fences
   - `<Fragment>` inside list items

## Test plan

- [x] Run `MARKFLOW_STATS=1 pnpm build` on withastro-docs
- [x] Verify build completes successfully (5,968 pages)
- [x] Confirm fallback rate is ~4.85%

🤖 Generated with [Claude Code](https://claude.com/claude-code)