### PR TITLE
fix: keep jsx inline inside tables

### DIFF
--- a/crates/core/src/renderer/mdast/context.rs
+++ b/crates/core/src/renderer/mdast/context.rs
@@ -117,6 +117,16 @@ impl<'a> Context<'a> {
         self.stack.iter().any(|scope| matches!(scope, Scope::List))
     }
 
+    /// Returns true if any scope in the stack is within a table structure.
+    ///
+    /// Table content must remain phrasing content; inserting block
+    /// boundaries inside <table>/<tr>/<td> produces invalid HTML.
+    pub fn is_in_table(&self) -> bool {
+        self.stack
+            .iter()
+            .any(|scope| matches!(scope, Scope::Table | Scope::TableRow | Scope::TableCell))
+    }
+
     /// Enters a new scope by pushing it onto the stack.
     pub fn enter(&mut self, scope: Scope) {
         self.stack.push(scope);

--- a/crates/core/src/renderer/mdast/mod.rs
+++ b/crates/core/src/renderer/mdast/mod.rs
@@ -585,4 +585,46 @@ line3
             assert!(slot_html.contains("Some tip content"));
         }
     }
+
+    #[test]
+    fn test_jsx_component_inside_table_cell() {
+        let input = r#"| Header |
+| --- |
+| <Box>content</Box> |"#;
+
+        let options = Options {
+            enable_directives: true,
+            ..Default::default()
+        };
+
+        let result = to_blocks(input, &options).unwrap();
+        assert_eq!(result.blocks.len(), 1);
+
+        if let RenderBlock::Html { content } = &result.blocks[0] {
+            assert!(content.contains("<td><Box>content</Box></td>"));
+        } else {
+            panic!("Expected HTML block");
+        }
+    }
+
+    #[test]
+    fn test_mixed_text_and_component_inside_table_cell() {
+        let input = r#"| Col |
+| --- |
+| before <Aside type="note">tip</Aside> after |"#;
+
+        let options = Options {
+            enable_directives: true,
+            ..Default::default()
+        };
+
+        let result = to_blocks(input, &options).unwrap();
+        assert_eq!(result.blocks.len(), 1);
+
+        if let RenderBlock::Html { content } = &result.blocks[0] {
+            assert!(content.contains("<td>before <Aside type={\"note\"}>tip</Aside> after</td>"));
+        } else {
+            panic!("Expected HTML block");
+        }
+    }
 }

--- a/crates/core/src/renderer/mdast/render.rs
+++ b/crates/core/src/renderer/mdast/render.rs
@@ -102,6 +102,7 @@ fn render_table_row(
     aligns: &[markdown::mdast::AlignKind],
 ) {
     ctx.push_raw("<tr>");
+    ctx.enter(Scope::TableRow);
 
     for (i, cell) in row.children.iter().enumerate() {
         if let Node::TableCell(c) = cell {
@@ -119,15 +120,18 @@ fn render_table_row(
             };
 
             ctx.push_raw(&format!("<{}{}>", tag, align_attr));
+            ctx.enter(Scope::TableCell);
 
             for child in &c.children {
                 render_node(child, ctx);
             }
 
+            ctx.exit(); // TableCell
             ctx.push_raw(&format!("</{}>", tag));
         }
     }
 
+    ctx.exit(); // TableRow
     ctx.push_raw("</tr>");
 }
 
@@ -225,7 +229,7 @@ fn render_jsx(
     }
 
     // 7. Push as component block
-    if ctx.is_in_list() {
+    if ctx.is_in_list() || ctx.is_in_table() {
         ctx.push_component_inline(tag_name, &props, &slot_html);
     } else {
         ctx.push_component(tag_name, props, slot_html);
@@ -387,6 +391,7 @@ pub fn render_node(node: &Node, ctx: &mut Context) {
         }
 
         Node::Table(table) => {
+            ctx.enter(Scope::Table);
             ctx.push_raw("<table>");
 
             ctx.push_raw("<thead>");
@@ -406,6 +411,7 @@ pub fn render_node(node: &Node, ctx: &mut Context) {
             }
 
             ctx.push_raw("</table>");
+            ctx.exit(); // Table
         }
 
         Node::TableRow(_) => {}

--- a/crates/core/src/renderer/mdast/types.rs
+++ b/crates/core/src/renderer/mdast/types.rs
@@ -97,6 +97,12 @@ pub enum Scope {
     Paragraph,
     /// Inside a list element (`<ul>` or `<ol>`).
     List,
+    /// Inside a table element (`<table>`).
+    Table,
+    /// Inside a table row element (`<tr>`).
+    TableRow,
+    /// Inside a table cell element (`<td>` or `<th>`).
+    TableCell,
     /// Inside an Aside component with associated metadata.
     Aside(AsideMeta),
     /// Inside a Card component with associated metadata.


### PR DESCRIPTION
## Summary
## Linked Issues
- Closes #

## Tasks from TODO.md
- [ ] Task 1.x: ...

## Performance Evidence
## Verification Steps
1. `npm install && npm run build:napi`
2. `node scripts/smoke-napi.mjs samples/large.md`
3. Result: ...

## Checklist
- [ ] `cargo fmt` executed?
- [ ] `cargo clippy` passed?
- [ ] Tests passed?
- [ ] No secrets included?
