### PR TITLE
fix(astro-markflow): fix typecheck null vs undefined for registry param

### DIFF
--- a/packages/astro-markflow/src/transforms/blocks-to-jsx.ts
+++ b/packages/astro-markflow/src/transforms/blocks-to-jsx.ts
@@ -294,7 +294,7 @@ export function blocksToJsx(
 
       // Convert slotChildren to HTML string for slot processing
       let effectiveSlot = stripParagraphFragmentWrappers(
-        slotChildrenToHtml(block.slotChildren ?? [], options.expressiveCodeComponent, componentImports, registry, userImportedNames)
+        slotChildrenToHtml(block.slotChildren ?? [], options.expressiveCodeComponent, componentImports, registry ?? undefined, userImportedNames)
       );
 
       if (isDirective && registry && block.name) {


### PR DESCRIPTION
## Summary
- Fix CI typecheck failure on main caused by passing `Registry | null` to a parameter expecting `Registry | undefined`
- Apply `registry ?? undefined` coercion at the call site in `blocks-to-jsx.ts:297`

## Test plan
- [x] `pnpm --dir packages/astro-markflow run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)