### PR TITLE
fix: prevent false Prism import from set:html content

### DIFF
--- a/packages/astro-markflow/src/transforms/inject-components.test.ts
+++ b/packages/astro-markflow/src/transforms/inject-components.test.ts
@@ -252,7 +252,7 @@ export default function Content() {
     expect(result).toContain(ASTRO_COMPONENTS_MODULE);
   });
 
-  it('should inject Prism component', () => {
+  it('should not inject Prism (not a built-in Astro component)', () => {
     const code = `
 export default function Content() {
   return <Prism lang="js">const x = 1;</Prism>;
@@ -260,11 +260,11 @@ export default function Content() {
 
     const result = injectAstroComponents(code);
 
-    expect(result).toContain('import { Prism }');
-    expect(result).toContain(ASTRO_COMPONENTS_MODULE);
+    expect(result).not.toContain('import { Prism }');
+    expect(result).toBe(code);
   });
 
-  it('should inject both Code and Prism', () => {
+  it('should only inject Code when both Code and Prism are used', () => {
     const code = `
 export default function Content() {
   return (
@@ -277,7 +277,8 @@ export default function Content() {
 
     const result = injectAstroComponents(code);
 
-    expect(result).toContain('import { Code, Prism }');
+    expect(result).toContain('import { Code }');
+    expect(result).not.toContain('import { Code, Prism }');
   });
 
   it('should not inject if no Astro components used', () => {

--- a/packages/astro-markflow/src/transforms/inject-components.ts
+++ b/packages/astro-markflow/src/transforms/inject-components.ts
@@ -9,6 +9,11 @@ import { collectImportedNames, insertAfterImports } from '../utils/imports.js';
 import { resolveStarlightConfig, type StarlightUserConfig } from '../utils/config.js';
 import { stripHeadingsMeta } from '../utils/validation.js';
 
+/** Strip set:html={...} string content to avoid false component matches in code blocks */
+function stripSetHtmlContent(code: string): string {
+  return code.replace(/set:html=\{("(?:[^"\\]|\\.)*")\}/g, 'set:html={""}');
+}
+
 /**
  * Generic component import injection.
  * Scans code for component usage and injects missing imports.
@@ -30,7 +35,7 @@ export function injectComponentImports(
   if (!code || typeof code !== 'string' || components.length === 0) {
     return code;
   }
-  const scanTarget = stripHeadingsMeta(code);
+  const scanTarget = stripSetHtmlContent(stripHeadingsMeta(code));
 
   // PERF: Use single combined regex instead of per-component regex
   // This reduces from O(n) regex compilations to O(1)
@@ -123,7 +128,7 @@ export function injectComponentImportsFromRegistry(
     return code;
   }
 
-  const scanTarget = stripHeadingsMeta(code);
+  const scanTarget = stripSetHtmlContent(stripHeadingsMeta(code));
   const imported = collectImportedNames(code);
 
   // PERF: Use single combined regex instead of per-component regex

--- a/packages/markflow/src/registry/presets/astro.ts
+++ b/packages/markflow/src/registry/presets/astro.ts
@@ -11,7 +11,6 @@ export const astroLibrary: ComponentLibrary = {
   defaultModulePath: 'astro/components',
   components: [
     { name: 'Code', modulePath: 'astro/components', exportType: 'named' },
-    { name: 'Prism', modulePath: 'astro/components', exportType: 'named' },
   ],
   directiveMappings: [],
 };


### PR DESCRIPTION
## Summary
- Add `stripSetHtmlContent()` to prevent false component matches inside `set:html` string content (e.g., `<Prism>` appearing in code block output)
- Remove Prism from the astro built-in component library since it is not a built-in Astro component
- Update tests to reflect Prism removal

## Test plan
- [x] Existing inject-components tests updated and passing
- [ ] Verify no regressions with `pnpm --dir packages/astro-markflow test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)